### PR TITLE
Add local streaming API example

### DIFF
--- a/examples/streamable_transport/main.go
+++ b/examples/streamable_transport/main.go
@@ -2,14 +2,20 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/Raezil/UTCP" // where your streamable_transport.go lives
 )
 
 func main() {
+	// 1) Start a simple HTTP server that provides tools
+	go startToolServer(":8080")
+	time.Sleep(200 * time.Millisecond)
+
 	logger := func(format string, args ...interface{}) {
 		log.Printf(format, args...)
 	}
@@ -18,14 +24,10 @@ func main() {
 
 	// Use the UTCP-defined provider type so the type-assertion passes:
 	provider := &UTCP.StreamableHttpProvider{
-		URL: "https://api.example.com/tools",
-		Headers: map[string]string{
-			"Authorization":   "Bearer <YOUR_TOKEN>",
-			"X-Custom-Header": "foobar",
-		},
+		URL: "http://localhost:8080/tools",
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	tools, err := transport.RegisterToolProvider(ctx, provider)
@@ -37,6 +39,7 @@ func main() {
 		fmt.Printf(" • %s: %s\n", t.Name, t.Description)
 	}
 
+	// Call the translateText tool
 	result, err := transport.CallTool(ctx, "translateText", map[string]interface{}{
 		"text": "Hello, world!",
 		"to":   "es",
@@ -49,4 +52,46 @@ func main() {
 	if err := transport.DeregisterToolProvider(ctx, provider); err != nil {
 		log.Printf("warning: failed to deregister provider: %v", err)
 	}
+}
+
+// Tool metadata returned by our local server
+type Tool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+var toolList = []Tool{
+	{
+		Name:        "translateText",
+		Description: "Translates text to a target language",
+	},
+}
+
+func startToolServer(addr string) {
+	http.HandleFunc("/tools", listToolsHandler)
+	http.HandleFunc("/tools/translateText", callTranslateHandler)
+
+	log.Printf("🔧 Tool provider listening on %s …", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}
+
+func listToolsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"tools": toolList})
+}
+
+func callTranslateHandler(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Text string `json:"text"`
+		To   string `json:"to"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	result := map[string]string{"translatedText": fmt.Sprintf("%s (%s)", req.Text, req.To)}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"result": result})
 }


### PR DESCRIPTION
## Summary
- create a small local server in `examples/streamable_transport/main.go`
- register and invoke the server instead of a remote URL

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878f45e9008832294d9d302f496117c