### PR TITLE
Add extra tests

### DIFF
--- a/grpc_transport_test.go
+++ b/grpc_transport_test.go
@@ -1,0 +1,73 @@
+package utcp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/grpcpb"
+
+	"google.golang.org/grpc"
+)
+
+type dummyGRPCServer struct {
+	grpcpb.UnimplementedUTCPServiceServer
+}
+
+func (s *dummyGRPCServer) GetManual(ctx context.Context, _ *grpcpb.Empty) (*grpcpb.Manual, error) {
+	return &grpcpb.Manual{Version: "1.0", Tools: []*grpcpb.Tool{{Name: "ping"}}}, nil
+}
+
+func (s *dummyGRPCServer) CallTool(ctx context.Context, req *grpcpb.ToolCallRequest) (*grpcpb.ToolCallResponse, error) {
+	var m map[string]any
+	_ = json.Unmarshal([]byte(req.ArgsJson), &m)
+	b, _ := json.Marshal(map[string]any{"pong": m["msg"]})
+	return &grpcpb.ToolCallResponse{ResultJson: string(b)}, nil
+}
+
+func startDummyGRPC(t *testing.T) (*grpc.Server, *GRPCProvider) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	grpcpb.RegisterUTCPServiceServer(srv, &dummyGRPCServer{})
+	go srv.Serve(lis)
+	prov := &GRPCProvider{BaseProvider: BaseProvider{Name: "g", ProviderType: ProviderGRPC}, Host: "127.0.0.1", Port: lis.Addr().(*net.TCPAddr).Port}
+	return srv, prov
+}
+
+func TestGRPCTransport_RegisterAndCall(t *testing.T) {
+	srv, prov := startDummyGRPC(t)
+	defer srv.Stop()
+	tr := NewGRPCClientTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil || len(tools) != 1 || tools[0].Name != "ping" {
+		t.Fatalf("register error: %v tools:%v", err, tools)
+	}
+	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]any)
+	if !ok || m["pong"] != "hi" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}
+
+func TestGRPCTransport_Errors(t *testing.T) {
+	tr := NewGRPCClientTransport(nil)
+	badProv := &GRPCProvider{BaseProvider: BaseProvider{Name: "g", ProviderType: ProviderGRPC}, Host: "127.0.0.1", Port: 1, UseSSL: true}
+	_, err := tr.RegisterToolProvider(context.Background(), badProv)
+	if err == nil {
+		t.Fatal("expected error for SSL")
+	}
+	if err := tr.DeregisterToolProvider(context.Background(), &HttpProvider{}); err == nil {
+		t.Fatal("expected type error")
+	}
+	if _, err := tr.CallTool(context.Background(), "ping", nil, &HttpProvider{}, nil); err == nil {
+		t.Fatal("expected type error")
+	}
+}

--- a/grpcpb/coverage_test.go
+++ b/grpcpb/coverage_test.go
@@ -1,0 +1,83 @@
+package grpcpb
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+type dummyServer struct {
+	UnimplementedUTCPServiceServer
+}
+
+func (d *dummyServer) GetManual(context.Context, *Empty) (*Manual, error) {
+	return &Manual{}, nil
+}
+func (d *dummyServer) CallTool(context.Context, *ToolCallRequest) (*ToolCallResponse, error) {
+	return &ToolCallResponse{}, nil
+}
+
+func TestCoverage(t *testing.T) {
+	e := &Empty{}
+	e.Reset()
+	e.ProtoMessage()
+	_ = e.String()
+	_ = e.ProtoReflect()
+	_, _ = e.Descriptor()
+
+	tl := &Tool{Name: "n", Description: "d"}
+	tl.Reset()
+	tl.ProtoMessage()
+	_ = tl.String()
+	_ = tl.ProtoReflect()
+	_, _ = tl.Descriptor()
+	_ = tl.GetName()
+	_ = tl.GetDescription()
+
+	m := &Manual{Version: "1", Tools: []*Tool{tl}}
+	m.Reset()
+	m.ProtoMessage()
+	_ = m.String()
+	_ = m.ProtoReflect()
+	_, _ = m.Descriptor()
+	_ = m.GetVersion()
+	_ = m.GetTools()
+
+	req := &ToolCallRequest{Tool: "ping", ArgsJson: "{}"}
+	req.Reset()
+	req.ProtoMessage()
+	_ = req.String()
+	_ = req.ProtoReflect()
+	_, _ = req.Descriptor()
+	_ = req.GetTool()
+	_ = req.GetArgsJson()
+
+	resp := &ToolCallResponse{ResultJson: "{}"}
+	resp.Reset()
+	resp.ProtoMessage()
+	_ = resp.String()
+	_ = resp.ProtoReflect()
+	_, _ = resp.Descriptor()
+	_ = resp.GetResultJson()
+
+	_ = file_grpcpb_utcp_proto_rawDescGZIP()
+
+	srv := grpc.NewServer()
+	RegisterUTCPServiceServer(srv, &dummyServer{})
+	conn := fakeConn{}
+	c := NewUTCPServiceClient(conn)
+	c.GetManual(context.Background(), &Empty{})
+	c.CallTool(context.Background(), &ToolCallRequest{})
+	_, _ = _UTCPService_GetManual_Handler(&dummyServer{}, context.Background(), func(v interface{}) error { return nil }, nil)
+	_, _ = _UTCPService_CallTool_Handler(&dummyServer{}, context.Background(), func(v interface{}) error { return nil }, nil)
+}
+
+type fakeConn struct{}
+
+func (fakeConn) Invoke(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error {
+	return nil
+}
+func (fakeConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}

--- a/sse_client_transport_additional2_test.go
+++ b/sse_client_transport_additional2_test.go
@@ -1,0 +1,21 @@
+package utcp
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestHandleSSE(t *testing.T) {
+	data := "id:1\n" +
+		"data: {\"a\":1}\n\n" +
+		"data: {\"b\":2}\n\n"
+	tr := NewSSETransport(nil)
+	events, err := tr.handleSSE(io.NopCloser(strings.NewReader(data)))
+	if err != nil {
+		t.Fatalf("handleSSE error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+}

--- a/tcp_transport_additional_test.go
+++ b/tcp_transport_additional_test.go
@@ -1,0 +1,16 @@
+package utcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTCPTransport_DeregisterAndClose(t *testing.T) {
+	tr := NewTCPClientTransport(nil)
+	if err := tr.DeregisterToolProvider(context.Background(), &TCPProvider{}); err != nil {
+		t.Fatalf("deregister error: %v", err)
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+}

--- a/udp_transport_additional_test.go
+++ b/udp_transport_additional_test.go
@@ -1,0 +1,13 @@
+package utcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUDPTransport_Deregister(t *testing.T) {
+	tr := NewUDPTransport(nil)
+	if err := tr.DeregisterToolProvider(context.Background(), &UDPProvider{}); err != nil {
+		t.Fatalf("deregister error: %v", err)
+	}
+}

--- a/webrtc_transport.go
+++ b/webrtc_transport.go
@@ -13,6 +13,8 @@ import (
 	webrtc "github.com/pion/webrtc/v3"
 )
 
+var newPeerConnection = webrtc.NewPeerConnection
+
 // WebRTCClientTransport implements ClientTransport using WebRTC data channels.
 type WebRTCClientTransport struct {
 	pc      *webrtc.PeerConnection
@@ -35,7 +37,7 @@ func (t *WebRTCClientTransport) openConnection(ctx context.Context, prov *WebRTC
 		return nil, nil
 	}
 	config := webrtc.Configuration{}
-	pc, err := webrtc.NewPeerConnection(config)
+	pc, err := newPeerConnection(config)
 	if err != nil {
 		return nil, err
 	}

--- a/webrtc_transport_integration_test.go
+++ b/webrtc_transport_integration_test.go
@@ -1,0 +1,87 @@
+package utcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	webrtc "github.com/pion/webrtc/v3"
+)
+
+type signalingServer struct {
+	pc  *webrtc.PeerConnection
+	srv *httptest.Server
+}
+
+func newSignalingServer(t *testing.T) *signalingServer {
+	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &signalingServer{pc: pc}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]string
+		json.NewDecoder(r.Body).Decode(&req)
+		offer := webrtc.SessionDescription{Type: webrtc.SDPTypeOffer, SDP: req["sdp"]}
+		if err := pc.SetRemoteDescription(offer); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		answer, err := pc.CreateAnswer(nil)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if err := pc.SetLocalDescription(answer); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		<-webrtc.GatheringCompletePromise(pc)
+		resp := map[string]any{"sdp": pc.LocalDescription().SDP, "tools": []map[string]any{{"name": "echo"}}}
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/candidate", func(w http.ResponseWriter, r *http.Request) {
+		// ignore candidates
+	})
+	server.srv = httptest.NewServer(mux)
+	pc.OnDataChannel(func(dc *webrtc.DataChannel) {
+		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+			var env map[string]any
+			json.Unmarshal(msg.Data, &env)
+			id := env["id"].(string)
+			args := env["args"].(map[string]any)
+			out, _ := json.Marshal(map[string]any{"id": id, "result": map[string]any{"echo": args["msg"]}})
+			dc.SendText(string(out))
+		})
+	})
+	return server
+}
+
+func (s *signalingServer) close() { s.srv.Close(); s.pc.Close() }
+
+func TestWebRTCTransport_RegisterAndCall(t *testing.T) {
+	srv := newSignalingServer(t)
+	defer srv.close()
+
+	prov := &WebRTCProvider{BaseProvider: BaseProvider{Name: "w", ProviderType: ProviderWebRTC}, SignalingServer: srv.srv.URL, PeerID: "peer", DataChannelName: "data"}
+	tr := NewWebRTCClientTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil || len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("register: %v tools:%v", err, tools)
+	}
+	res, err := tr.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	m, ok := res.(map[string]any)
+	if !ok || m["echo"] != "hi" {
+		t.Fatalf("bad result: %#v", res)
+	}
+	if err := tr.DeregisterToolProvider(ctx, prov); err != nil {
+		t.Fatalf("dereg: %v", err)
+	}
+}

--- a/websocket_transport_additional_test.go
+++ b/websocket_transport_additional_test.go
@@ -1,0 +1,53 @@
+package utcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestWebSocketTransportApplyAuth_Basic(t *testing.T) {
+	tr := NewWebSocketTransport(nil)
+	var a Auth = NewBasicAuth("u", "p")
+	prov := &WebSocketProvider{Auth: &a}
+	hdr := http.Header{}
+	if err := tr.applyAuth(hdr, prov); err != nil {
+		t.Fatalf("applyAuth error: %v", err)
+	}
+	if hdr.Get("Authorization") == "" {
+		t.Errorf("expected Authorization header set")
+	}
+}
+
+func TestWebSocketTransportApplyAuth_Unsupported(t *testing.T) {
+	tr := NewWebSocketTransport(nil)
+	var dummyAuth Auth = &OAuth2Auth{TokenURL: "t", ClientID: "c", ClientSecret: "s"}
+	prov := &WebSocketProvider{Auth: &dummyAuth}
+	hdr := http.Header{}
+	if err := tr.applyAuth(hdr, prov); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestWebSocketTransport_RegisterWrongType(t *testing.T) {
+	tr := NewWebSocketTransport(nil)
+	_, err := tr.RegisterToolProvider(context.Background(), &HttpProvider{})
+	if err == nil {
+		t.Fatal("expected type error")
+	}
+}
+
+func TestWebSocketTransport_CallWrongType(t *testing.T) {
+	tr := NewWebSocketTransport(nil)
+	_, err := tr.CallTool(context.Background(), "x", nil, &HttpProvider{}, nil)
+	if err == nil {
+		t.Fatal("expected type error")
+	}
+}
+
+func TestWebSocketTransport_DeregisterWrongType(t *testing.T) {
+	tr := NewWebSocketTransport(nil)
+	if err := tr.DeregisterToolProvider(context.Background(), &HttpProvider{}); err == nil {
+		t.Fatal("expected type error")
+	}
+}


### PR DESCRIPTION
## Summary
- add more tests for transports and gRPC proto
- add integration test for WebRTC transport
- minor tweak to allow peer connection override

## Testing
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_687b4872cf888322bbf22b66b9c7d5a6