### PR TITLE
Add standard /utcp endpoints

### DIFF
--- a/examples/http_client/main.go
+++ b/examples/http_client/main.go
@@ -17,7 +17,7 @@ import (
 var discovered bool
 
 func startServer(addr string) {
-	http.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/utcp", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return

--- a/examples/http_client/provider.json
+++ b/examples/http_client/provider.json
@@ -4,7 +4,7 @@
       "provider_type": "http",
       "name": "http",
       "http_method": "POST",
-      "url": "http://localhost:8080/tools",
+      "url": "http://localhost:8080/utcp",
       "headers": {
         "Content-Type": "application/json"
       }

--- a/examples/http_transport/main.go
+++ b/examples/http_transport/main.go
@@ -45,14 +45,14 @@ func main() {
 	time.Sleep(200 * time.Millisecond)
 
 	// 3) Run the client that discovers & calls "echo"
-	runClient("http://localhost:8080/tools")
+	runClient("http://localhost:8080/utcp")
 }
 
 // startToolServer boots the HTTP API that lists & invokes tools.
 func startToolServer(addr string) {
 	r := mux.NewRouter()
-	r.HandleFunc("/tools", listToolsHandler).Methods("GET")
-	r.HandleFunc("/tools/{name}/call", callToolHandler).Methods("POST")
+	r.HandleFunc("/utcp", listToolsHandler).Methods("GET")
+	r.HandleFunc("/utcp/{name}", callToolHandler).Methods("POST")
 
 	srv := &http.Server{
 		Handler:      r,
@@ -152,7 +152,7 @@ func runClient(baseURL string) {
 
 	// Provider for tool calling (different URL pattern and POST method)
 	callProvider := &providers.HttpProvider{
-		URL:        "http://localhost:8080/tools/echo/call",
+		URL:        "http://localhost:8080/utcp/echo",
 		HTTPMethod: "POST",
 		Headers:    map[string]string{"Content-Type": "application/json"},
 	}
@@ -167,7 +167,7 @@ func runClient(baseURL string) {
 
 	// Call "timestamp" tool (send empty JSON object)
 	timestampProvider := &providers.HttpProvider{
-		URL:        "http://localhost:8080/tools/timestamp/call",
+		URL:        "http://localhost:8080/utcp/timestamp",
 		HTTPMethod: "POST",
 		Headers:    map[string]string{"Content-Type": "application/json"},
 	}

--- a/examples/sse_client/main.go
+++ b/examples/sse_client/main.go
@@ -16,7 +16,7 @@ import (
 
 func startServer(addr string) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp", func(w http.ResponseWriter, r *http.Request) {
 		// Open the JSON file
 		f, err := os.Open("tools.json")
 		if err != nil {
@@ -32,7 +32,7 @@ func startServer(addr string) {
 			log.Printf("error writing tools.json: %v", err)
 		}
 	})
-	mux.HandleFunc("/tools/sse.hello", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp/sse.hello", func(w http.ResponseWriter, r *http.Request) {
 		var in map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&in)
 		name, _ := in["name"].(string)

--- a/examples/sse_client/provider.json
+++ b/examples/sse_client/provider.json
@@ -2,7 +2,7 @@
   "providers": [{
     "provider_type": "sse",
     "name": "sse",
-    "url": "http://localhost:8080/tools"
+    "url": "http://localhost:8080/utcp"
     }
   ]
 }

--- a/examples/sse_transport/main.go
+++ b/examples/sse_transport/main.go
@@ -28,7 +28,7 @@ func main() {
 func startMockServer(addr string) {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp", func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]interface{}{
 			"version": "1.0",
 			"tools": []map[string]interface{}{
@@ -39,7 +39,7 @@ func startMockServer(addr string) {
 		json.NewEncoder(w).Encode(resp)
 	})
 
-	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp/hello", func(w http.ResponseWriter, r *http.Request) {
 		var in map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&in)
 		name, _ := in["name"].(string)
@@ -88,7 +88,7 @@ func runClient(baseURL string) {
 	transport := transports.NewSSETransport(logger)
 
 	// Discovery endpoint
-	provider := &providers.SSEProvider{URL: baseURL + "/tools"}
+	provider := &providers.SSEProvider{URL: baseURL + "/utcp"}
 	tools, err := transport.RegisterToolProvider(ctx, provider)
 	if err != nil {
 		panic(fmt.Errorf("failed to register SSE tools: %w", err))
@@ -99,7 +99,7 @@ func runClient(baseURL string) {
 	}
 
 	// Update URL for tool calls
-	provider.URL = baseURL
+	provider.URL = baseURL + "/utcp"
 	// Call with streaming
 	res, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider, nil)
 	if err != nil {

--- a/examples/streamable_client/provider.json
+++ b/examples/streamable_client/provider.json
@@ -3,7 +3,7 @@
     {
       "provider_type": "http_stream",
       "name": "http_stream",
-      "url": "http://localhost:8080/tools",
+      "url": "http://localhost:8080/utcp",
       "http_method": "POST"
     }
   ]

--- a/examples/streamable_transport/main.go
+++ b/examples/streamable_transport/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	// 3) Point at your provider
 	provider := &providers.StreamableHttpProvider{
-		URL:     "http://localhost:8080/tools",
+		URL:     "http://localhost:8080/utcp",
 		Headers: map[string]string{}, // add auth here if needed
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -57,7 +57,7 @@ func startStreamingServer(addr string) {
 	mux := http.NewServeMux()
 
 	// Discovery endpoint:
-	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		manual := map[string]interface{}{
 			"version": "1.0",
@@ -72,7 +72,7 @@ func startStreamingServer(addr string) {
 	})
 
 	// Streaming tool endpoint:
-	mux.HandleFunc("/tools/streamNumbers", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/utcp/streamNumbers", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		flusher, ok := w.(http.Flusher)
 		if !ok {

--- a/examples/tcp_client/main.go
+++ b/examples/tcp_client/main.go
@@ -53,7 +53,7 @@ func (s *tcpServer) handle(c net.Conn) {
 
 	log.Printf("Received request: %+v", req)
 
-	if req.Action == "list" {
+	if req.Action == "utcp" {
 		manual := map[string]interface{}{
 			"version": "1.0",
 			"tools": []map[string]interface{}{

--- a/examples/tcp_transport/main.go
+++ b/examples/tcp_transport/main.go
@@ -51,7 +51,7 @@ func (s *tcpServer) handle(c net.Conn) {
 	if err := dec.Decode(&req); err != nil {
 		return
 	}
-	if req.Action == "list" {
+	if req.Action == "utcp" {
 		manual := map[string]interface{}{
 			"version": "1.0",
 			"tools": []map[string]interface{}{

--- a/examples/udp_client/main.go
+++ b/examples/udp_client/main.go
@@ -54,7 +54,7 @@ func (s *udpServer) loop(manual UtcpManual) {
 		data := buf[:n]
 
 		// Discovery request
-		if string(data) == "DISCOVER" {
+		if string(data) == "UTCP" {
 			out, _ := json.Marshal(manual)
 			s.conn.WriteToUDP(out, remote)
 			continue

--- a/examples/udp_transport/main.go
+++ b/examples/udp_transport/main.go
@@ -43,7 +43,7 @@ func (s *udpServer) loop() {
 			return
 		}
 		data := buf[:n]
-		if string(data) == "DISCOVER" {
+		if string(data) == "UTCP" {
 			manual := UtcpManual{Version: "1.0", Tools: []Tool{{Name: "udp_echo", Description: "Echo"}}}
 			out, _ := json.Marshal(manual)
 			s.conn.WriteToUDP(out, remote)

--- a/examples/websocket_client/main.go
+++ b/examples/websocket_client/main.go
@@ -78,8 +78,8 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func startServer(addr string) {
-	http.HandleFunc("/tools", toolsHandler)
-	http.HandleFunc("/websocket.echo", echoHandler)
+	http.HandleFunc("/utcp", toolsHandler)
+	http.HandleFunc("/utcp/echo", echoHandler)
 	log.Printf("WebSocket server listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/examples/websocket_client/provider.json
+++ b/examples/websocket_client/provider.json
@@ -3,7 +3,7 @@
     {
       "provider_type": "websocket",
       "name": "websocket",
-      "url": "ws://localhost:8080/tools"
+      "url": "ws://localhost:8080/utcp"
     }
   ]
 }

--- a/examples/websocket_transport/main.go
+++ b/examples/websocket_transport/main.go
@@ -29,14 +29,14 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 	defer c.Close()
 
 	switch r.URL.Path {
-	case "/tools":
+	case "/utcp":
 		_, msg, err := c.ReadMessage()
 		if err != nil || string(msg) != "manual" {
 			return
 		}
 		manual := UtcpManual{Version: "1.0", Tools: tools}
 		c.WriteJSON(manual)
-	case "/echo":
+	case "/utcp/echo":
 		var in map[string]any
 		if err := c.ReadJSON(&in); err != nil {
 			return
@@ -46,8 +46,8 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func startServer(addr string) {
-	http.HandleFunc("/tools", wsHandler)
-	http.HandleFunc("/echo", wsHandler)
+	http.HandleFunc("/utcp", wsHandler)
+	http.HandleFunc("/utcp/echo", wsHandler)
 	log.Printf("WebSocket server listening on %s", addr)
 	http.ListenAndServe(addr, nil)
 }
@@ -58,7 +58,7 @@ func main() {
 
 	logger := func(format string, args ...interface{}) { log.Printf(format, args...) }
 	transport := transports.NewWebSocketTransport(logger)
-	wsURL := "ws://localhost:8080/tools"
+	wsURL := "ws://localhost:8080/utcp"
 	prov := &providers.WebSocketProvider{BaseProvider: BaseProvider{Name: "ws", ProviderType: ProviderWebSocket}, URL: wsURL}
 
 	ctx := context.Background()

--- a/src/transports/tcp/tcp_transport.go
+++ b/src/transports/tcp/tcp_transport.go
@@ -53,7 +53,7 @@ func (t *TCPClientTransport) RegisterToolProvider(ctx context.Context, prov Prov
 	defer conn.Close()
 
 	// Request manual
-	req := map[string]string{"action": "list"}
+	req := map[string]string{"action": "utcp"}
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		return nil, err
 	}

--- a/src/transports/tcp/tcp_transport_test.go
+++ b/src/transports/tcp/tcp_transport_test.go
@@ -43,7 +43,7 @@ func (s *tcpTestServer) handle(conn net.Conn) {
 	if err := dec.Decode(&req); err != nil {
 		return
 	}
-	if req["action"] == "list" {
+	if req["action"] == "utcp" {
 		resp := map[string]interface{}{
 			"version": "1.0",
 			"tools":   []map[string]interface{}{{"name": "ping", "description": "Ping"}},

--- a/src/transports/udp/udp_transport.go
+++ b/src/transports/udp/udp_transport.go
@@ -53,7 +53,7 @@ func (t *UDPTransport) writeAndRead(ctx context.Context, addr string, timeout ti
 	return buf[:n], nil
 }
 
-// RegisterToolProvider discovers tools by sending a DISCOVER message to the server.
+// RegisterToolProvider discovers tools by sending a UTCP message to the server.
 func (t *UDPTransport) RegisterToolProvider(ctx context.Context, prov Provider) ([]Tool, error) {
 	p, ok := prov.(*UDPProvider)
 	if !ok {
@@ -61,7 +61,7 @@ func (t *UDPTransport) RegisterToolProvider(ctx context.Context, prov Provider) 
 	}
 	addr := fmt.Sprintf("%s:%d", p.Host, p.Port)
 	timeout := time.Duration(p.Timeout) * time.Millisecond
-	resp, err := t.writeAndRead(ctx, addr, timeout, []byte("DISCOVER"))
+	resp, err := t.writeAndRead(ctx, addr, timeout, []byte("UTCP"))
 	if err != nil {
 		return nil, err
 	}

--- a/src/transports/udp/udp_transport_test.go
+++ b/src/transports/udp/udp_transport_test.go
@@ -58,7 +58,7 @@ func (s *udpServer) close() {
 
 func TestUDPTransport_RegisterAndCall(t *testing.T) {
 	server, err := startUDPServer(func(b []byte) []byte {
-		if string(b) == "DISCOVER" {
+		if string(b) == "UTCP" {
 			return []byte(`{"version":"1.0","tools":[{"name":"udp_echo","description":"Echo"}]}`)
 		}
 		var req map[string]any


### PR DESCRIPTION
## Summary
- change example servers to expose `/utcp` discovery and `/utcp/{name}` tool calls
- adjust provider configs in examples to use new endpoints
- update UDP/TCP transports and tests to use new `UTCP` discovery message

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6883cb26cf088322b379c9e077403d4a