### PR TITLE
Unify MCP CallTool handling

### DIFF
--- a/src/transports/mcp/mcp_transport_http_test.go
+++ b/src/transports/mcp/mcp_transport_http_test.go
@@ -99,9 +99,6 @@ func TestMCPHTTPStreamReturnsStreamResult(t *testing.T) {
 	prov := &providers.MCPProvider{
 		Name: "demo",
 		URL:  "http://localhost:8099/mcp",
-		StreamingTools: []string{
-			"count",
-		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- remove StreamingTools check in CallTool
- call stream handler for both MCP HTTP and stdio tools
- infer if streaming should be returned in CallTool
- update MCP HTTP transport test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887b6802b708322a9a32f951eb73746