### PR TITLE
feat: add call tool stream to UTCP

### DIFF
--- a/examples/mcp_http_client/main.go
+++ b/examples/mcp_http_client/main.go
@@ -39,8 +39,7 @@ func main() {
 	}
 	fmt.Println(res)
 	// Call streaming tool: returns StreamResult
-	ctxWithCT := context.WithValue(ctx, "contentType", "event-stream")
-	res, err = client.CallTool(ctxWithCT, tools[1].Name, map[string]any{
+	res, err = client.CallToolStream(ctx, tools[1].Name, map[string]any{
 		"count": 5,
 	})
 	if err != nil {
@@ -48,17 +47,9 @@ func main() {
 	}
 
 	// Expect StreamResult
-	sub, ok := res.(transports.StreamResult)
-	if !ok {
-		log.Fatalf("unexpected type: %T", res)
-	}
-	if err != nil {
-		log.Fatalf("streaming call error: %v", err)
-	}
-	defer sub.Close()
 
 	for {
-		item, err := sub.Next()
+		item, err := res.(transports.StreamResult).Next()
 		if err == io.EOF {
 			break
 		}

--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -65,4 +65,5 @@ func main() {
 
 	res, err := transport.CallTool(ctx, tools[0].Name, argsMap, mcpProvider, nil)
 	fmt.Println(res.(map[string]any))
+	res, err = transport.CallTool(ctx, tools[1], argsMap, mcpProvider, nil)
 }

--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -50,7 +50,9 @@ func main() {
 	for _, t := range tools {
 		fmt.Printf(" - %s: %s\n", t.Name, t.Description)
 	}
-
+	if len(tools) != 2 {
+		log.Fatalf("expected exactly two tools, got %d", len(tools))
+	}
 	// Choose the "hello" tool if available, otherwise pick the first one
 	var toolName string
 	for _, t := range tools {

--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 	"time"
 
 	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
@@ -53,18 +52,7 @@ func main() {
 	if len(tools) != 2 {
 		log.Fatalf("expected exactly two tools, got %d", len(tools))
 	}
-	// Choose the "hello" tool if available, otherwise pick the first one
-	var toolName string
-	for _, t := range tools {
-		if strings.HasSuffix(t.Name, "hello") {
-			toolName = t.Name
-			break
-		}
-	}
-	if toolName == "" {
-		toolName = tools[0].Name
-		fmt.Printf("WARNING: \"hello\" tool not found; defaulting to %s\n", toolName)
-	}
+
 	argsMap := map[string]any{"name": "Kamil"}
 
 	res, err := transport.CallTool(ctx, tools[0].Name, argsMap, mcpProvider, nil)

--- a/parse_and_process_test.go
+++ b/parse_and_process_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tag"
@@ -20,6 +21,10 @@ func (m *miniTransport) RegisterToolProvider(ctx context.Context, prov Provider)
 }
 func (m *miniTransport) DeregisterToolProvider(ctx context.Context, prov Provider) error { return nil }
 func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, l *string) (any, error) {
+	return nil, nil
+}
+
+func (m *miniTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
 	return nil, nil
 }
 

--- a/parse_and_process_test.go
+++ b/parse_and_process_test.go
@@ -3,6 +3,7 @@ package utcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
@@ -21,11 +22,11 @@ func (m *miniTransport) RegisterToolProvider(ctx context.Context, prov Provider)
 }
 func (m *miniTransport) DeregisterToolProvider(ctx context.Context, prov Provider) error { return nil }
 func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, l *string) (any, error) {
-	return nil, nil
+	return nil, errors.ErrUnsupported
 }
 
 func (m *miniTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
-	return nil, nil
+	return nil, errors.ErrUnsupported
 }
 
 func TestParseProvidersJSON(t *testing.T) {

--- a/src/repository/client_transport_interface.go
+++ b/src/repository/client_transport_interface.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 )
 
 // ClientTransport defines how a client registers, deregisters, and invokes UTCP tools.
@@ -19,4 +20,5 @@ type ClientTransport interface {
 	// CallTool invokes a named tool with the given arguments on a specific provider.
 	// It returns whatever the tool returns (often map[string]interface{} or a typed result).
 	CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, l *string) (any, error)
+	CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error)
 }

--- a/src/transports/cli/cli_transport.go
+++ b/src/transports/cli/cli_transport.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
@@ -254,4 +255,13 @@ func (t *CliTransport) CallTool(
 // Close cleans up resources (no-op).
 func (t *CliTransport) Close() error {
 	return nil
+}
+
+func (t *CliTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by CliTransport")
 }

--- a/src/transports/graphql/graphql_transport.go
+++ b/src/transports/graphql/graphql_transport.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/auth"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/graphql"
@@ -601,4 +602,13 @@ func (t *GraphQLClientTransport) Close() error {
 	t.oauthTokens = make(map[string]OAuth2TokenResponse)
 	t.mu.Unlock()
 	return nil
+}
+
+func (t *GraphQLClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by GraphQLClientTransport")
 }

--- a/src/transports/grpc/grpc_transport.go
+++ b/src/transports/grpc/grpc_transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/universal-tool-calling-protocol/go-utcp/src/grpcpb"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/grpc"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 )
@@ -103,3 +104,12 @@ func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, arg
 
 // Close cleans up (no-op).
 func (t *GRPCClientTransport) Close() error { return nil }
+
+func (t *GRPCClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by GRPCClientTransport")
+}

--- a/src/transports/http/http_transport.go
+++ b/src/transports/http/http_transport.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/auth"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
 
@@ -289,4 +290,13 @@ func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, arg
 	}
 
 	return result, nil
+}
+
+func (t *HttpClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by HttpClientTransport")
 }

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -601,8 +601,6 @@ func (t *MCPTransport) callStdioToolStream(ctx context.Context, process *mcpProc
 							"params": notification.Params,
 						}
 
-						t.logger("Received notification %d for tool '%s': %s", notificationCount, toolName, notification.Method)
-
 						select {
 						case resultChan <- notificationResult:
 						case <-ctx.Done():
@@ -633,7 +631,6 @@ func (t *MCPTransport) callStdioToolStream(ctx context.Context, process *mcpProc
 					}
 
 					// Send the final response
-					t.logger("Received final response for tool '%s' after %d notifications", toolName, notificationCount)
 					select {
 					case resultChan <- response.Result:
 					case <-ctx.Done():

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -260,19 +260,7 @@ func (t *MCPTransport) CallTool(
 	var res interface{}
 	var err error
 
-	// Check if the tool supports streaming
-	// Default to false, but check the context for content type
-	isEventStream := false
-	if ctFromCtx, ok := ctx.Value("contentType").(string); ok {
-		// fallback: context
-		isEventStream = (ctFromCtx == "event-stream")
-	}
-
 	switch {
-	case isEventStream:
-		// Streaming‑capable tools
-		res, err = t.callStreamingTool(ctx, toolName, args, p)
-
 	case proc.httpClient != nil:
 		// HTTP‑capable synchronous tools
 		res, err = t.callHTTPTool(ctx, proc.httpClient, toolName, args)
@@ -320,13 +308,13 @@ func (t *MCPTransport) callStdioTool(
 	return nil, fmt.Errorf("no output from tool %q", toolName)
 }
 
-func (t *MCPTransport) callStreamingTool(
+func (t *MCPTransport) CallToolStream(
 	ctx context.Context,
 	toolName string,
 	args map[string]any,
 	p Provider,
-) (interface{}, error) {
-	stream, err := t.CallToolStream(ctx, toolName, args, p)
+) (transports.StreamResult, error) {
+	stream, err := t.CallingToolStream(ctx, toolName, args, p)
 	if err != nil {
 		return nil, err
 	}
@@ -398,8 +386,8 @@ func (t *MCPTransport) callStreamingTool(
 	return transports.NewChannelStreamResult(ch, stream.Close), nil
 }
 
-// CallToolStream returns a transports.StreamResult for live streaming.
-func (t *MCPTransport) CallToolStream(
+// CallingToolStream returns a transports.StreamResult for live streaming.
+func (t *MCPTransport) CallingToolStream(
 	ctx context.Context,
 	toolName string,
 	args map[string]any,

--- a/src/transports/mcp/mcp_transport_http_test.go
+++ b/src/transports/mcp/mcp_transport_http_test.go
@@ -107,7 +107,7 @@ func TestMCPHTTPStreamReturnsStreamResult(t *testing.T) {
 	}
 	ctxWithCT := context.WithValue(ctx, "contentType", "event-stream")
 
-	res, err := tr.CallTool(ctxWithCT, "count", map[string]any{"n": 3}, prov, nil)
+	res, err := tr.CallToolStream(ctxWithCT, "count", map[string]any{"n": 3}, prov)
 	if err != nil {
 		t.Fatalf("call err: %v", err)
 	}

--- a/src/transports/sse/sse_client_transport.go
+++ b/src/transports/sse/sse_client_transport.go
@@ -260,3 +260,12 @@ func (t *SSEClientTransport) handleSSE(body io.ReadCloser) ([]interface{}, error
 	}
 	return events, nil
 }
+
+func (t *SSEClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by SSEClientTransport")
+}

--- a/src/transports/streamable/streamable_transport.go
+++ b/src/transports/streamable/streamable_transport.go
@@ -172,10 +172,8 @@ func (t *StreamableHTTPClientTransport) CallToolStream(
 	ctx context.Context,
 	toolName string,
 	args map[string]interface{},
-	prov Provider,
-	l *string,
-) (transports.StreamResult, error) {
-	result, err := t.CallTool(ctx, toolName, args, prov, l)
+	prov Provider) (transports.StreamResult, error) {
+	result, err := t.CallTool(ctx, toolName, args, prov, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/transports/tcp/tcp_transport.go
+++ b/src/transports/tcp/tcp_transport.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
@@ -110,3 +111,12 @@ func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args
 
 // Close cleans up resources (no-op).
 func (t *TCPClientTransport) Close() error { return nil }
+
+func (t *TCPClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by TCPClientTransport")
+}

--- a/src/transports/udp/udp_transport.go
+++ b/src/transports/udp/udp_transport.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	"time"
 
@@ -101,4 +102,13 @@ func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[s
 		return nil, err
 	}
 	return result, nil
+}
+
+func (t *UDPTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by UDPTransport")
 }

--- a/src/transports/webrtc/webrtc_transport.go
+++ b/src/transports/webrtc/webrtc_transport.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 )
@@ -207,4 +208,13 @@ func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, a
 		}
 		return res, nil
 	}
+}
+
+func (t *WebRTCClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by WebRTCClientTransport")
 }

--- a/src/transports/websocket/websocket_transport.go
+++ b/src/transports/websocket/websocket_transport.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 	streamresult "github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
@@ -158,4 +159,13 @@ func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string
 	}
 
 	return streamresult.NewSliceStreamResult(results, nil), nil
+}
+
+func (t *WebSocketClientTransport) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+	p Provider,
+) (transports.StreamResult, error) {
+	return nil, errors.New("streaming not supported by WebSocketClientTransport")
 }

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/helpers"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tag"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 
@@ -51,6 +52,7 @@ type UtcpClientInterface interface {
 	CallTool(ctx context.Context, toolName string, args map[string]any) (any, error)
 	SearchTools(query string, limit int) ([]Tool, error)
 	GetTransports() map[string]ClientTransport
+	CallToolStream(ctx context.Context, toolName string, args map[string]any) (transports.StreamResult, error)
 }
 
 // UtcpClient holds all state and implements UtcpClientInterface.
@@ -582,4 +584,56 @@ func (c *UtcpClient) processProvider(ctx context.Context, raw map[string]any, in
 
 func (u *UtcpClient) GetTransports() map[string]ClientTransport {
 	return u.transports
+}
+
+func (c *UtcpClient) CallToolStream(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+) (transports.StreamResult, error) {
+	parts := strings.SplitN(toolName, ".", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid tool name: %s", toolName)
+	}
+	providerName := parts[0]
+
+	prov, err := c.toolRepository.GetProvider(ctx, providerName)
+	if err != nil {
+		return nil, err
+	}
+	if prov == nil {
+		return nil, fmt.Errorf("provider not found: %s", providerName)
+	}
+
+	tools, err := c.toolRepository.GetToolsByProvider(ctx, providerName)
+	if err != nil {
+		return nil, err
+	}
+	var selectedTool *Tool
+	for _, t := range tools {
+		if t.Name == toolName {
+			selectedTool = &t
+			break
+		}
+	}
+	if selectedTool == nil {
+		return nil, fmt.Errorf("tool not found: %s", toolName)
+	}
+
+	// re‑substitute any provider vars before call
+	*prov = c.substituteProviderVariables(*prov)
+
+	tr, ok := c.transports[string((*prov).Type())]
+	if !ok {
+		return nil, fmt.Errorf("no transport for provider type %s", (*prov).Type())
+	}
+
+	// Determine remote method name for MCP transport
+	callName := toolName
+	if (*prov).Type() == ProviderMCP {
+		// Strip provider prefix for MCP transport
+		callName = parts[1]
+	}
+
+	return tr.CallToolStream(ctx, callName, args, *prov)
 }

--- a/utcp_client_additional_test.go
+++ b/utcp_client_additional_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
@@ -55,6 +56,10 @@ func (s *stubTransport) DeregisterToolProvider(ctx context.Context, prov Provide
 func (s *stubTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
 	s.callCalled = true
 	return "ok", nil
+}
+
+func (m *stubTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
+	return nil, nil
 }
 
 func TestGetVariableSources(t *testing.T) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added CallToolStream to UTCP, allowing clients to call tools that return streaming results.

- **New Features**
  - Introduced CallToolStream method to UtcpClient and ClientTransport interface.
  - Implemented streaming support for MCP transport.
  - Updated examples and tests to use CallToolStream.
  - Other transports return an error if streaming is not supported.

<!-- End of auto-generated description by cubic. -->

