### PR TITLE
feat: adding stream bool to CallTool method in transports and utcp cl…

### DIFF
--- a/examples/cli_client/main.go
+++ b/examples/cli_client/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	fmt.Printf("Calling tool '%s' with input: %v\n", tool.Name, input)
-	result, err := client.CallTool(ctx, tool.Name, input)
+	result, err := client.CallTool(ctx, tool.Name, input, false)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 

--- a/examples/cli_transport/main.go
+++ b/examples/cli_transport/main.go
@@ -61,7 +61,7 @@ func main() {
 	fmt.Printf("Calling tool '%s' with input: %v\n", tool.Name, input)
 
 	// Call the tool directly using the transport
-	result, err := transport.CallTool(ctx, tool.Name, input, provider, nil)
+	result, err := transport.CallTool(ctx, tool.Name, input, provider, false)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 		fmt.Printf("Error type: %T\n", err)

--- a/examples/graphql_client/main.go
+++ b/examples/graphql_client/main.go
@@ -207,14 +207,14 @@ func main() {
 	}
 
 	// Example query
-	res, err := client.CallTool(ctx, "graphql.echo", map[string]any{"msg": "hi"})
+	res, err := client.CallTool(ctx, "graphql.echo", map[string]any{"msg": "hi"}, false)
 	if err != nil {
 		log.Fatalf("query call error: %v", err)
 	}
 	log.Printf("Query result: %#v", res)
 
 	// Example subscription
-	subRes, err := client.CallTool(ctx, "graphqlsub.updates", nil)
+	subRes, err := client.CallTool(ctx, "graphqlsub.updates", nil, true)
 	if err != nil {
 		log.Fatalf("subscription call error: %v", err)
 	}

--- a/examples/graphql_transport/main.go
+++ b/examples/graphql_transport/main.go
@@ -136,7 +136,7 @@ func main() {
 	variables := map[string]any{
 		"limit": "3",
 	}
-	result, err := transport.CallTool(ctx, "launchesPast", variables, provider, nil)
+	result, err := transport.CallTool(ctx, "launchesPast", variables, provider, false)
 	if err != nil {
 		log.Fatalf("GraphQL query failed: %v", err)
 	}

--- a/examples/grpc_client/main.go
+++ b/examples/grpc_client/main.go
@@ -147,7 +147,7 @@ func main() {
 		{"grpc.uppercase", map[string]any{"msg": "hello"}},
 		{"grpc.wordcount", map[string]any{"msg": "Hello world from Go server"}},
 	} {
-		res, err := client.CallTool(ctx, call.method, call.args)
+		res, err := client.CallTool(ctx, call.method, call.args, false)
 		if err != nil {
 			log.Fatalf("call %s error: %v", call.method, err)
 		}

--- a/examples/grpc_transport/main.go
+++ b/examples/grpc_transport/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/http_client/main.go
+++ b/examples/http_client/main.go
@@ -135,14 +135,14 @@ func main() {
 	}
 
 	// Call the "echo" tool
-	res, err := client.CallTool(ctx, "http.echo", map[string]any{"message": "hi"})
+	res, err := client.CallTool(ctx, "http.echo", map[string]any{"message": "hi"}, false)
 	if err != nil {
 		log.Fatalf("call echo: %v", err)
 	}
 	fmt.Printf("Echo result: %#v\n", res)
 
 	// Call the "timestamp" tool
-	ts, err := client.CallTool(ctx, "http.timestamp", map[string]any{})
+	ts, err := client.CallTool(ctx, "http.timestamp", map[string]any{}, false)
 	if err != nil {
 		log.Fatalf("call timestamp: %v", err)
 	}

--- a/examples/http_transport/main.go
+++ b/examples/http_transport/main.go
@@ -159,7 +159,7 @@ func runClient(baseURL string) {
 
 	// Call "echo" tool
 	args := map[string]interface{}{"message": "Hello from Go!"}
-	result, err := transport.CallTool(ctx, "echo", args, callProvider, nil)
+	result, err := transport.CallTool(ctx, "echo", args, callProvider, false)
 	if err != nil {
 		log.Fatalf("CallTool error: %v", err)
 	}
@@ -172,7 +172,7 @@ func runClient(baseURL string) {
 		Headers:    map[string]string{"Content-Type": "application/json"},
 	}
 
-	timestampResult, err := transport.CallTool(ctx, "timestamp", map[string]interface{}{}, timestampProvider, nil)
+	timestampResult, err := transport.CallTool(ctx, "timestamp", map[string]interface{}{}, timestampProvider, false)
 	if err != nil {
 		log.Fatalf("CallTool timestamp error: %v", err)
 	}

--- a/examples/mcp_client/main.go
+++ b/examples/mcp_client/main.go
@@ -30,7 +30,7 @@ func main() {
 	args := map[string]any{
 		"name": "Kamil",
 	}
-	data, err := client.CallTool(ctx, tools[0].Name, args)
+	data, err := client.CallTool(ctx, tools[0].Name, args, false)
 	if err != nil {
 		log.Fatalf("cannot proceed")
 	}

--- a/examples/mcp_http_client/main.go
+++ b/examples/mcp_http_client/main.go
@@ -33,15 +33,15 @@ func main() {
 	}
 
 	// Call hello tool
-	res, err := client.CallTool(ctx, tools[0].Name, map[string]any{"name": "Go"})
+	res, err := client.CallTool(ctx, tools[0].Name, map[string]any{"name": "Go"}, false)
 	if err != nil {
 		log.Fatalf("hello call error: %v", err)
 	}
 	fmt.Println(res)
 	// Call streaming tool: returns StreamResult
-	res, err = client.CallToolStream(ctx, tools[1].Name, map[string]any{
+	res, err = client.CallTool(ctx, tools[1].Name, map[string]any{
 		"count": 5,
-	})
+	}, true)
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)
 	}

--- a/examples/mcp_http_transport/main.go
+++ b/examples/mcp_http_transport/main.go
@@ -86,15 +86,13 @@ func main() {
 	}
 
 	// 5) Call hello tool
-	result, err := transport.CallTool(ctx, "hello", map[string]any{"name": "Go"}, provider, nil)
+	result, err := transport.CallTool(ctx, "hello", map[string]any{"name": "Go"}, provider, false)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}
 	fmt.Printf("Hello result: %#v\n", result)
 
-	ctxWithCT := context.WithValue(ctx, "contentType", "event-stream")
-
-	result, err = transport.CallToolStream(ctxWithCT, "count_stream", map[string]any{"count": 5, "contentType": "event-stream"}, provider)
+	result, err = transport.CallTool(ctx, "count_stream", map[string]any{"count": 5, "contentType": "event-stream"}, provider, true)
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)
 	}

--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -55,9 +55,9 @@ func main() {
 
 	argsMap := map[string]any{"name": "Kamil"}
 
-	res, err := transport.CallTool(ctx, tools[0].Name, argsMap, mcpProvider, nil)
+	res, err := transport.CallTool(ctx, tools[0].Name, argsMap, mcpProvider, false)
 	fmt.Println(res.(map[string]any))
-	res, err = transport.CallToolStream(ctx, tools[1].Name, argsMap, mcpProvider)
+	res, err = transport.CallTool(ctx, tools[1].Name, argsMap, mcpProvider, true)
 
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)

--- a/examples/sse_client/main.go
+++ b/examples/sse_client/main.go
@@ -82,7 +82,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := client.CallTool(ctx, "sse.hello", map[string]any{"name": "UTCP"})
+	res, err := client.CallTool(ctx, "sse.hello", map[string]any{"name": "UTCP"}, true)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/sse_transport/main.go
+++ b/examples/sse_transport/main.go
@@ -103,7 +103,7 @@ func runClient(baseURL string) {
 	// Update URL for tool calls
 	provider.URL = baseURL
 	// Call with streaming
-	res, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider, nil)
+	res, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider, true)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/streamable_client/main.go
+++ b/examples/streamable_client/main.go
@@ -97,7 +97,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := client.CallTool(ctx, "http_stream.streamNumbers", nil)
+	res, err := client.CallTool(ctx, "http_stream.streamNumbers", nil, true)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/streamable_transport/main.go
+++ b/examples/streamable_transport/main.go
@@ -43,8 +43,7 @@ func main() {
 	for _, t := range tools {
 		log.Printf(" • %s: %s", t.Name, t.Description)
 	}
-	var lastChunk string
-	res, err := transport.CallTool(ctx, "streamNumbers", nil, provider, &lastChunk)
+	res, err := transport.CallTool(ctx, "streamNumbers", nil, provider, true)
 	if err != nil {
 		log.Fatalf("CallTool error: %v", err)
 	}

--- a/examples/tcp_client/main.go
+++ b/examples/tcp_client/main.go
@@ -8,7 +8,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/universal-tool-calling-protocol/go-utcp/src/providers"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
 	transports "github.com/universal-tool-calling-protocol/go-utcp/src/transports/tcp"
 )
 
@@ -93,9 +94,9 @@ func main() {
 	logger := func(format string, args ...interface{}) { log.Printf("[CLIENT] "+format, args...) }
 	transport := transports.NewTCPClientTransport(logger)
 	prov := &providers.TCPProvider{
-		BaseProvider: providers.BaseProvider{
+		BaseProvider: base.BaseProvider{
 			Name:         "tcp",
-			ProviderType: providers.ProviderTCP,
+			ProviderType: base.ProviderTCP,
 		},
 		Host:    "127.0.0.1",
 		Port:    9090,
@@ -117,7 +118,7 @@ func main() {
 		log.Fatal("No tools discovered!")
 	}
 
-	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, nil)
+	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, false)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/tcp_transport/main.go
+++ b/examples/tcp_transport/main.go
@@ -93,7 +93,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, nil)
+	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, false)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/udp_client/main.go
+++ b/examples/udp_client/main.go
@@ -103,7 +103,7 @@ func main() {
 	}
 
 	// Call the udp_echo tool
-	res, err := client.CallTool(ctx, "udp.udp_echo", map[string]any{"msg": "hi"})
+	res, err := client.CallTool(ctx, "udp.udp_echo", map[string]any{"msg": "hi"}, false)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/udp_transport/main.go
+++ b/examples/udp_transport/main.go
@@ -85,7 +85,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := transport.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := transport.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/webrtc_client/main.go
+++ b/examples/webrtc_client/main.go
@@ -211,7 +211,7 @@ func main() {
 	}
 
 	log.Println("Attempting to call echo tool...")
-	res, err := client.CallTool(ctx, "webrtc.echo", map[string]any{"msg": "Hello, WebRTC!"})
+	res, err := client.CallTool(ctx, "webrtc.echo", map[string]any{"msg": "Hello, WebRTC!"}, true)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/webrtc_transport/main.go
+++ b/examples/webrtc_transport/main.go
@@ -120,7 +120,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 	// call echo
-	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "Hello, WebRTC!"}, prov, nil)
+	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "Hello, WebRTC!"}, prov, true)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/websocket_client/main.go
+++ b/examples/websocket_client/main.go
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	// Call the streaming tool
-	res, err := client.CallTool(ctx, "websocket.multipleChunks", map[string]any{})
+	res, err := client.CallTool(ctx, "websocket.multipleChunks", map[string]any{}, true)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/websocket_transport/main.go
+++ b/examples/websocket_transport/main.go
@@ -71,7 +71,7 @@ func main() {
 		log.Printf(" - %s: %s", t.Name, t.Description)
 	}
 
-	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hello"}, prov, nil)
+	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hello"}, prov, true)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/parse_and_process_test.go
+++ b/parse_and_process_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tag"
@@ -21,11 +20,7 @@ func (m *miniTransport) RegisterToolProvider(ctx context.Context, prov Provider)
 	return []Tool{{Name: "x"}}, nil
 }
 func (m *miniTransport) DeregisterToolProvider(ctx context.Context, prov Provider) error { return nil }
-func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, l *string) (any, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (m *miniTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
+func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, stream bool) (any, error) {
 	return nil, errors.ErrUnsupported
 }
 

--- a/src/repository/client_transport_interface.go
+++ b/src/repository/client_transport_interface.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 )
 
 // ClientTransport defines how a client registers, deregisters, and invokes UTCP tools.
@@ -19,6 +18,5 @@ type ClientTransport interface {
 
 	// CallTool invokes a named tool with the given arguments on a specific provider.
 	// It returns whatever the tool returns (often map[string]interface{} or a typed result).
-	CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, l *string) (any, error)
-	CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error)
+	CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, stream bool) (any, error)
 }

--- a/src/transports/cli/cli_transport.go
+++ b/src/transports/cli/cli_transport.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
@@ -204,7 +203,7 @@ func (t *CliTransport) CallTool(
 	toolName string,
 	args map[string]interface{},
 	prov Provider,
-	l *string,
+	stream bool,
 ) (interface{}, error) {
 	cliProv, ok := prov.(*CliProvider)
 	if !ok || cliProv.CommandName == "" {
@@ -255,13 +254,4 @@ func (t *CliTransport) CallTool(
 // Close cleans up resources (no-op).
 func (t *CliTransport) Close() error {
 	return nil
-}
-
-func (t *CliTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by CliTransport")
 }

--- a/src/transports/cli/cli_transport_register_call_test.go
+++ b/src/transports/cli/cli_transport_register_call_test.go
@@ -27,7 +27,7 @@ func TestCliTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("register error %v tools %v", err, tools)
 	}
 
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{}, prov, nil)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport.go
+++ b/src/transports/graphql/graphql_transport.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/auth"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/graphql"
@@ -329,7 +328,7 @@ func (t *GraphQLClientTransport) DeregisterToolProvider(ctx context.Context, man
 }
 
 // CallTool executes a GraphQL operation by name with proper type support.
-func (t *GraphQLClientTransport) CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, l *string) (any, error) {
+func (t *GraphQLClientTransport) CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, stream bool) (any, error) {
 	prov, ok := toolProvider.(*GraphQLProvider)
 	if !ok {
 		return nil, errors.New("GraphQLClientTransport can only be used with GraphQLProvider")
@@ -602,13 +601,4 @@ func (t *GraphQLClientTransport) Close() error {
 	t.oauthTokens = make(map[string]OAuth2TokenResponse)
 	t.mu.Unlock()
 	return nil
-}
-
-func (t *GraphQLClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming is supported, use CallTool")
 }

--- a/src/transports/graphql/graphql_transport_additional_test.go
+++ b/src/transports/graphql/graphql_transport_additional_test.go
@@ -120,14 +120,14 @@ func TestGraphQL_RegisterAndCall_Errors(t *testing.T) {
 	if _, err := tr.RegisterToolProvider(ctx, &CliProvider{}); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
-	if _, err := tr.CallTool(ctx, "x", nil, &CliProvider{}, nil); err == nil {
+	if _, err := tr.CallTool(ctx, "x", nil, &CliProvider{}, false); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
 	prov := &GraphQLProvider{URL: "http://example.com"}
 	if _, err := tr.RegisterToolProvider(ctx, prov); err == nil {
 		t.Fatalf("expected https enforcement error")
 	}
-	if _, err := tr.CallTool(ctx, "foo", nil, prov, nil); err == nil {
+	if _, err := tr.CallTool(ctx, "foo", nil, prov, false); err == nil {
 		t.Fatalf("expected https enforcement error")
 	}
 }
@@ -140,7 +140,7 @@ func TestGraphQL_CallTool_NoData(t *testing.T) {
 	defer server.Close()
 	prov := &GraphQLProvider{URL: server.URL}
 	tr := NewGraphQLClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "foo", nil, prov, nil)
+	res, err := tr.CallTool(context.Background(), "foo", nil, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport_subscription_test.go
+++ b/src/transports/graphql/graphql_transport_subscription_test.go
@@ -75,7 +75,7 @@ func TestGraphQLClientTransport_OperationType(t *testing.T) {
 
 	prov := &GraphQLProvider{URL: server.URL, OperationType: "subscription"}
 	tr := NewGraphQLClientTransport(nil)
-	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, nil); err != nil {
+	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, false); err != nil {
 		t.Fatalf("call error: %v", err)
 	}
 	if !strings.HasPrefix(gotQuery, "subscription ") {
@@ -83,7 +83,7 @@ func TestGraphQLClientTransport_OperationType(t *testing.T) {
 	}
 
 	prov.OperationType = "mutation"
-	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, nil); err != nil {
+	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, false); err != nil {
 		t.Fatalf("call error: %v", err)
 	}
 	if !strings.HasPrefix(gotQuery, "mutation ") {

--- a/src/transports/graphql/graphql_transport_test.go
+++ b/src/transports/graphql/graphql_transport_test.go
@@ -52,7 +52,7 @@ func TestGraphQLClientTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("expected 1 tool, got %d: %+v", len(tools), tools)
 	}
 
-	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{"name": "bob"}, prov, nil)
+	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{"name": "bob"}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport_websocket_test.go
+++ b/src/transports/graphql/graphql_transport_websocket_test.go
@@ -51,7 +51,7 @@ func TestGraphQLClientTransport_WebSocketSubscription(t *testing.T) {
 
 	prov := &GraphQLProvider{BaseProvider: BaseProvider{ProviderType: ProviderGraphQL}, URL: wsURL, OperationType: "subscription"}
 	tr := NewGraphQLClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "updates", nil, prov, nil)
+	res, err := tr.CallTool(context.Background(), "updates", nil, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/grpc/grpc_transport.go
+++ b/src/transports/grpc/grpc_transport.go
@@ -12,7 +12,6 @@ import (
 	"github.com/universal-tool-calling-protocol/go-utcp/src/grpcpb"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/grpc"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 )
@@ -76,7 +75,7 @@ func (t *GRPCClientTransport) DeregisterToolProvider(ctx context.Context, prov P
 }
 
 // CallTool invokes the CallTool RPC on the UTCPService.
-func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	gp, ok := prov.(*GRPCProvider)
 	if !ok {
 		return nil, errors.New("GRPCClientTransport can only be used with GRPCProvider")
@@ -104,12 +103,3 @@ func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, arg
 
 // Close cleans up (no-op).
 func (t *GRPCClientTransport) Close() error { return nil }
-
-func (t *GRPCClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by GRPCClientTransport")
-}

--- a/src/transports/grpc/grpc_transport_test.go
+++ b/src/transports/grpc/grpc_transport_test.go
@@ -51,7 +51,7 @@ func TestGRPCTransport_RegisterAndCall(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "ping" {
 		t.Fatalf("register error: %v tools:%v", err, tools)
 	}
-	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestGRPCTransport_Errors(t *testing.T) {
 	if err := tr.DeregisterToolProvider(context.Background(), &HttpProvider{}); err == nil {
 		t.Fatal("expected type error")
 	}
-	if _, err := tr.CallTool(context.Background(), "ping", nil, &HttpProvider{}, nil); err == nil {
+	if _, err := tr.CallTool(context.Background(), "ping", nil, &HttpProvider{}, false); err == nil {
 		t.Fatal("expected type error")
 	}
 }

--- a/src/transports/http/http_transport.go
+++ b/src/transports/http/http_transport.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/auth"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
 
@@ -199,7 +198,7 @@ func (t *HttpClientTransport) RegisterToolProvider(ctx context.Context, p Provid
 }
 
 // CallTool calls a specific tool on the HTTP provider.
-func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, p Provider, l *string) (any, error) {
+func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, p Provider, stream bool) (any, error) {
 	hp, ok := p.(*HttpProvider)
 	if !ok {
 		return nil, errors.New("HttpTransport can only be used with HttpProvider")
@@ -290,13 +289,4 @@ func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, arg
 	}
 
 	return result, nil
-}
-
-func (t *HttpClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by HttpClientTransport")
 }

--- a/src/transports/http/http_transport_additional_test.go
+++ b/src/transports/http/http_transport_additional_test.go
@@ -25,7 +25,7 @@ func TestHttpTransport_CallTool_Error(t *testing.T) {
 	defer server.Close()
 	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL}
 	tr := NewHttpClientTransport(nil)
-	_, err := tr.CallTool(context.Background(), "t", map[string]any{}, prov, nil)
+	_, err := tr.CallTool(context.Background(), "t", map[string]any{}, prov, false)
 	if err == nil {
 		t.Fatalf("expected error from call")
 	}
@@ -41,7 +41,7 @@ func TestHttpTransport_CallTool_PathSub(t *testing.T) {
 	defer server.Close()
 	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL + "/{id}"}
 	tr := NewHttpClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov, nil)
+	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/http/http_transport_test.go
+++ b/src/transports/http/http_transport_test.go
@@ -42,7 +42,7 @@ func TestHttpClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL + "/ping"
-	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, nil)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -241,7 +241,7 @@ func (t *MCPTransport) CallTool(
 	toolName string,
 	args map[string]any,
 	p Provider,
-	_l *string,
+	stream bool,
 ) (interface{}, error) {
 	mp, ok := p.(*MCPProvider)
 	if !ok {
@@ -261,6 +261,8 @@ func (t *MCPTransport) CallTool(
 	var err error
 
 	switch {
+	case stream == true:
+		res, err = t.CallToolStream(ctx, toolName, args, p)
 	case proc.httpClient != nil:
 		// HTTP‑capable synchronous tools
 		res, err = t.callHTTPTool(ctx, proc.httpClient, toolName, args)

--- a/src/transports/mcp/mcp_transport_additional_test.go
+++ b/src/transports/mcp/mcp_transport_additional_test.go
@@ -22,7 +22,7 @@ func TestMCPTransport_Errors(t *testing.T) {
 		t.Fatalf("expected error for wrong provider")
 	}
 	// wrong provider for call
-	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, nil); err == nil {
+	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, false); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
 	// proper provider succeeds
@@ -30,7 +30,7 @@ func TestMCPTransport_Errors(t *testing.T) {
 	if _, err := tr.RegisterToolProvider(ctx, prov); err != nil {
 		t.Fatalf("register err: %v", err)
 	}
-	if res, err := tr.CallTool(ctx, "hello", nil, prov, nil); err != nil {
+	if res, err := tr.CallTool(ctx, "hello", nil, prov, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if res == nil {
 		t.Fatalf("expected non-nil result")

--- a/src/transports/mcp/mcp_transport_http_test.go
+++ b/src/transports/mcp/mcp_transport_http_test.go
@@ -46,7 +46,7 @@ func TestMCPHTTPNonStreamReturnsMap(t *testing.T) {
 		t.Fatalf("register err: %v", err)
 	}
 
-	res, err := tr.CallTool(ctx, "hello", map[string]any{"name": "Go"}, prov, nil)
+	res, err := tr.CallTool(ctx, "hello", map[string]any{"name": "Go"}, prov, false)
 	if err != nil {
 		t.Fatalf("call err: %v", err)
 	}

--- a/src/transports/mcp/mcp_transport_test.go
+++ b/src/transports/mcp/mcp_transport_test.go
@@ -20,7 +20,7 @@ func TestMCPClientTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("expected non-nil tools")
 	}
 
-	if res, err := tr.CallTool(ctx, "hello", nil, prov, nil); err != nil {
+	if res, err := tr.CallTool(ctx, "hello", nil, prov, false); err != nil {
 		t.Fatalf("call error: %v", err)
 	} else if res == nil {
 		t.Fatalf("expected non-nil result")

--- a/src/transports/sse/sse_client_transport.go
+++ b/src/transports/sse/sse_client_transport.go
@@ -79,7 +79,7 @@ func (t *SSEClientTransport) DeregisterToolProvider(ctx context.Context, prov Pr
 }
 
 // CallTool invokes a named tool, using SSE if available.
-func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args map[string]interface{}, prov Provider, lastEventID *string) (interface{}, error) {
+func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args map[string]interface{}, prov Provider, stream bool) (interface{}, error) {
 	sseProv, ok := prov.(*SSEProvider)
 	if !ok {
 		return nil, errors.New("SSEClientTransport can only be used with SSEProvider")
@@ -103,6 +103,7 @@ func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
+	lastEventID, ok := args["lastEventID"].(*string)
 	if lastEventID != nil {
 		req.Header.Set("Last-Event-ID", *lastEventID)
 	}
@@ -259,13 +260,4 @@ func (t *SSEClientTransport) handleSSE(body io.ReadCloser) ([]interface{}, error
 		}
 	}
 	return events, nil
-}
-
-func (t *SSEClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming is supported by SSEClientTransport, use CallTool")
 }

--- a/src/transports/sse/sse_client_transport_test.go
+++ b/src/transports/sse/sse_client_transport_test.go
@@ -44,7 +44,7 @@ func TestSSEClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi", "lastEventID": nil}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/streamable/streamable_transport.go
+++ b/src/transports/streamable/streamable_transport.go
@@ -69,7 +69,7 @@ func (t *StreamableHTTPClientTransport) CallTool(
 	toolName string,
 	args map[string]interface{},
 	prov Provider,
-	l *string,
+	stream bool,
 ) (interface{}, error) {
 	streamProv, ok := prov.(*StreamableHttpProvider)
 	if !ok {
@@ -102,6 +102,7 @@ func (t *StreamableHTTPClientTransport) CallTool(
 
 	// Create a channel for streaming results
 	resultCh := make(chan any, 10) // Buffer to prevent blocking
+	var l *string
 
 	// Start a goroutine to process the stream
 	go func() {
@@ -173,7 +174,7 @@ func (t *StreamableHTTPClientTransport) CallToolStream(
 	toolName string,
 	args map[string]interface{},
 	prov Provider) (transports.StreamResult, error) {
-	result, err := t.CallTool(ctx, toolName, args, prov, nil)
+	result, err := t.CallTool(ctx, toolName, args, prov, true)
 	if err != nil {
 		return nil, err
 	}

--- a/src/transports/streamable/streamable_transport_test.go
+++ b/src/transports/streamable/streamable_transport_test.go
@@ -49,7 +49,7 @@ func TestStreamableHTTPClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, true)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/tcp/tcp_transport.go
+++ b/src/transports/tcp/tcp_transport.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
@@ -75,7 +74,7 @@ func (t *TCPClientTransport) DeregisterToolProvider(ctx context.Context, prov Pr
 }
 
 // CallTool connects to the provider and sends a tool invocation request.
-func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, requestID *string) (any, error) {
+func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	tcpProv, ok := prov.(*TCPProvider)
 	if !ok {
 		return nil, errors.New("TCPClientTransport can only be used with TCPProvider")
@@ -111,12 +110,3 @@ func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args
 
 // Close cleans up resources (no-op).
 func (t *TCPClientTransport) Close() error { return nil }
-
-func (t *TCPClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by TCPClientTransport")
-}

--- a/src/transports/tcp/tcp_transport_test.go
+++ b/src/transports/tcp/tcp_transport_test.go
@@ -74,7 +74,7 @@ func TestTCPClientTransport_RegisterAndCall(t *testing.T) {
 	if len(tools) != 1 || tools[0].Name != "ping" {
 		t.Fatalf("unexpected tools: %+v", tools)
 	}
-	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, nil)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/udp/udp_transport.go
+++ b/src/transports/udp/udp_transport.go
@@ -8,7 +8,6 @@ import (
 	"net"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	"time"
 
@@ -82,7 +81,7 @@ func (t *UDPTransport) DeregisterToolProvider(ctx context.Context, prov Provider
 }
 
 // CallTool sends a JSON request with tool name and arguments and waits for the response.
-func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	p, ok := prov.(*UDPProvider)
 	if !ok {
 		return nil, errors.New("UDPTransport can only be used with UDPProvider")
@@ -102,13 +101,4 @@ func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[s
 		return nil, err
 	}
 	return result, nil
-}
-
-func (t *UDPTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by UDPTransport")
 }

--- a/src/transports/udp/udp_transport_test.go
+++ b/src/transports/udp/udp_transport_test.go
@@ -89,7 +89,7 @@ func TestUDPTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("unexpected tools: %+v", tools)
 	}
 
-	res, err := tr.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/webrtc/webrtc_transport.go
+++ b/src/transports/webrtc/webrtc_transport.go
@@ -14,7 +14,6 @@ import (
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 )
@@ -174,7 +173,7 @@ func (t *WebRTCClientTransport) DeregisterToolProvider(ctx context.Context, prov
 	return nil
 }
 
-func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	if t.dc == nil {
 		return nil, errors.New("data channel not established")
 	}
@@ -191,7 +190,7 @@ func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, a
 	t.mu.Lock()
 	t.pending[id] = respCh
 	t.mu.Unlock()
-
+	var l *string
 	// Send request
 	if err := t.dc.SendText(string(payload)); err != nil {
 		return nil, err
@@ -208,13 +207,4 @@ func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, a
 		}
 		return res, nil
 	}
-}
-
-func (t *WebRTCClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by WebRTCClientTransport")
 }

--- a/src/transports/webrtc/webrtc_transport_integration_test.go
+++ b/src/transports/webrtc/webrtc_transport_integration_test.go
@@ -77,7 +77,7 @@ func TestWebRTCTransport_RegisterAndCall(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "echo" {
 		t.Fatalf("register: %v tools:%v", err, tools)
 	}
-	res, err := tr.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		t.Fatalf("call: %v", err)
 	}

--- a/src/transports/websocket/websocket_transport.go
+++ b/src/transports/websocket/websocket_transport.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 	streamresult "github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
@@ -103,7 +102,7 @@ func (t *WebSocketClientTransport) DeregisterToolProvider(ctx context.Context, p
 	return nil
 }
 
-func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	wsProv, ok := prov.(*WebSocketProvider)
 	if !ok {
 		return nil, errors.New("WebSocketClientTransport can only be used with WebSocketProvider")
@@ -159,13 +158,4 @@ func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string
 	}
 
 	return streamresult.NewSliceStreamResult(results, nil), nil
-}
-
-func (t *WebSocketClientTransport) CallToolStream(
-	ctx context.Context,
-	toolName string,
-	args map[string]any,
-	p Provider,
-) (transports.StreamResult, error) {
-	return nil, errors.New("streaming not supported by WebSocketClientTransport")
 }

--- a/src/transports/websocket/websocket_transport_additional_test.go
+++ b/src/transports/websocket/websocket_transport_additional_test.go
@@ -44,7 +44,7 @@ func TestWebSocketTransport_RegisterWrongType(t *testing.T) {
 
 func TestWebSocketTransport_CallWrongType(t *testing.T) {
 	tr := NewWebSocketTransport(nil)
-	_, err := tr.CallTool(context.Background(), "x", nil, &HttpProvider{}, nil)
+	_, err := tr.CallTool(context.Background(), "x", nil, &HttpProvider{}, false)
 	if err == nil {
 		t.Fatal("expected type error")
 	}

--- a/src/transports/websocket/websocket_transport_test.go
+++ b/src/transports/websocket/websocket_transport_test.go
@@ -59,7 +59,7 @@ func TestWebSocketTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = wsURL
-	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, nil)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, false)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/utcp_client_additional_test.go
+++ b/utcp_client_additional_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
-	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
@@ -53,13 +52,9 @@ func (s *stubTransport) DeregisterToolProvider(ctx context.Context, prov Provide
 	return nil
 }
 
-func (s *stubTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+func (s *stubTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
 	s.callCalled = true
 	return "ok", nil
-}
-
-func (m *stubTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
-	return nil, nil
 }
 
 func TestGetVariableSources(t *testing.T) {
@@ -169,7 +164,7 @@ func TestUtcpClientFlow(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "my_cli.echo" || !tr.registerCalled {
 		t.Fatalf("register failed: %v %v", tools, err)
 	}
-	if _, err := client.CallTool(ctx, "my_cli.echo", map[string]any{"a": 1}); err != nil || !tr.callCalled {
+	if _, err := client.CallTool(ctx, "my_cli.echo", map[string]any{"a": 1}, false); err != nil || !tr.callCalled {
 		t.Fatalf("call failed: %v", err)
 	}
 	res, err := client.SearchTools("my_cli", 10)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a stream boolean to the CallTool method in all client transports and the utcp client, replacing the previous CallToolStream method and simplifying streaming tool calls.

- **Refactors**
  - Updated CallTool signatures to include a stream flag across all transports and client code.
  - Removed CallToolStream methods and related code.

<!-- End of auto-generated description by cubic. -->

