### PR TITLE
Replacing stream boolean with CallingOptions

### DIFF
--- a/examples/cli_client/main.go
+++ b/examples/cli_client/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	fmt.Printf("Calling tool '%s' with input: %v\n", tool.Name, input)
-	result, err := client.CallTool(ctx, tool.Name, input, false)
+	result, err := client.CallTool(ctx, tool.Name, input)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 

--- a/examples/graphql_transport/main.go
+++ b/examples/graphql_transport/main.go
@@ -136,7 +136,7 @@ func main() {
 	variables := map[string]any{
 		"limit": "3",
 	}
-	result, err := transport.CallTool(ctx, "launchesPast", variables, provider, false)
+	result, err := transport.CallTool(ctx, "launchesPast", variables, provider)
 	if err != nil {
 		log.Fatalf("GraphQL query failed: %v", err)
 	}

--- a/examples/http_client/main.go
+++ b/examples/http_client/main.go
@@ -135,14 +135,14 @@ func main() {
 	}
 
 	// Call the "echo" tool
-	res, err := client.CallTool(ctx, "http.echo", map[string]any{"message": "hi"}, false)
+	res, err := client.CallTool(ctx, "http.echo", map[string]any{"message": "hi"})
 	if err != nil {
 		log.Fatalf("call echo: %v", err)
 	}
 	fmt.Printf("Echo result: %#v\n", res)
 
 	// Call the "timestamp" tool
-	ts, err := client.CallTool(ctx, "http.timestamp", map[string]any{}, false)
+	ts, err := client.CallTool(ctx, "http.timestamp", map[string]any{})
 	if err != nil {
 		log.Fatalf("call timestamp: %v", err)
 	}

--- a/examples/mcp_client/main.go
+++ b/examples/mcp_client/main.go
@@ -30,7 +30,7 @@ func main() {
 	args := map[string]any{
 		"name": "Kamil",
 	}
-	data, err := client.CallTool(ctx, tools[0].Name, args, false)
+	data, err := client.CallTool(ctx, tools[0].Name, args)
 	if err != nil {
 		log.Fatalf("cannot proceed")
 	}

--- a/examples/mcp_http_client/main.go
+++ b/examples/mcp_http_client/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	utcp "github.com/universal-tool-calling-protocol/go-utcp"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 )
 
@@ -33,15 +34,18 @@ func main() {
 	}
 
 	// Call hello tool
-	res, err := client.CallTool(ctx, tools[0].Name, map[string]any{"name": "Go"}, false)
+	res, err := client.CallTool(ctx, tools[0].Name, map[string]any{"name": "Go"})
 	if err != nil {
 		log.Fatalf("hello call error: %v", err)
 	}
 	fmt.Println(res)
+	options := base.CallingOptions{
+		Stream: true,
+	}
 	// Call streaming tool: returns StreamResult
 	res, err = client.CallTool(ctx, tools[1].Name, map[string]any{
 		"count": 5,
-	}, true)
+	}, options)
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)
 	}

--- a/examples/mcp_http_client/main.go
+++ b/examples/mcp_http_client/main.go
@@ -39,13 +39,13 @@ func main() {
 		log.Fatalf("hello call error: %v", err)
 	}
 	fmt.Println(res)
-	options := base.CallingOptions{
+	opt := base.CallingOptions{
 		Stream: true,
 	}
 	// Call streaming tool: returns StreamResult
 	res, err = client.CallTool(ctx, tools[1].Name, map[string]any{
 		"count": 5,
-	}, options)
+	}, opt)
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)
 	}

--- a/examples/mcp_http_transport/main.go
+++ b/examples/mcp_http_transport/main.go
@@ -11,6 +11,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cast"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
 	transports "github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 	mcp_transport "github.com/universal-tool-calling-protocol/go-utcp/src/transports/mcp"
@@ -86,13 +87,15 @@ func main() {
 	}
 
 	// 5) Call hello tool
-	result, err := transport.CallTool(ctx, "hello", map[string]any{"name": "Go"}, provider, false)
+	result, err := transport.CallTool(ctx, "hello", map[string]any{"name": "Go"}, provider)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}
 	fmt.Printf("Hello result: %#v\n", result)
 
-	result, err = transport.CallTool(ctx, "count_stream", map[string]any{"count": 5, "contentType": "event-stream"}, provider, true)
+	result, err = transport.CallTool(ctx, "count_stream", map[string]any{"count": 5}, provider, base.CallingOptions{
+		Stream: true,
+	})
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)
 	}

--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
 	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 	mcp "github.com/universal-tool-calling-protocol/go-utcp/src/transports/mcp"
@@ -57,7 +58,9 @@ func main() {
 
 	res, err := transport.CallTool(ctx, tools[0].Name, argsMap, mcpProvider, false)
 	fmt.Println(res.(map[string]any))
-	res, err = transport.CallTool(ctx, tools[1].Name, argsMap, mcpProvider, true)
+	res, err = transport.CallTool(ctx, tools[1].Name, argsMap, mcpProvider, base.CallingOptions{
+		Stream: true,
+	})
 
 	if err != nil {
 		log.Fatalf("stream call error: %v", err)

--- a/examples/sse_client/main.go
+++ b/examples/sse_client/main.go
@@ -82,7 +82,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := client.CallTool(ctx, "sse.hello", map[string]any{"name": "UTCP"}, true)
+	res, err := client.CallTool(ctx, "sse.hello", map[string]any{"name": "UTCP"})
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/sse_transport/main.go
+++ b/examples/sse_transport/main.go
@@ -103,7 +103,7 @@ func runClient(baseURL string) {
 	// Update URL for tool calls
 	provider.URL = baseURL
 	// Call with streaming
-	res, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider, true)
+	res, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/streamable_client/main.go
+++ b/examples/streamable_client/main.go
@@ -97,7 +97,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := client.CallTool(ctx, "http_stream.streamNumbers", nil, true)
+	res, err := client.CallTool(ctx, "http_stream.streamNumbers", nil)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/streamable_transport/main.go
+++ b/examples/streamable_transport/main.go
@@ -43,7 +43,7 @@ func main() {
 	for _, t := range tools {
 		log.Printf(" • %s: %s", t.Name, t.Description)
 	}
-	res, err := transport.CallTool(ctx, "streamNumbers", nil, provider, true)
+	res, err := transport.CallTool(ctx, "streamNumbers", nil, provider)
 	if err != nil {
 		log.Fatalf("CallTool error: %v", err)
 	}

--- a/examples/tcp_client/main.go
+++ b/examples/tcp_client/main.go
@@ -118,7 +118,7 @@ func main() {
 		log.Fatal("No tools discovered!")
 	}
 
-	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, false)
+	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/tcp_transport/main.go
+++ b/examples/tcp_transport/main.go
@@ -93,7 +93,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov, false)
+	res, err := transport.CallTool(ctx, "ping", map[string]any{}, prov)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/udp_client/main.go
+++ b/examples/udp_client/main.go
@@ -103,7 +103,7 @@ func main() {
 	}
 
 	// Call the udp_echo tool
-	res, err := client.CallTool(ctx, "udp.udp_echo", map[string]any{"msg": "hi"}, false)
+	res, err := client.CallTool(ctx, "udp.udp_echo", map[string]any{"msg": "hi"})
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/udp_transport/main.go
+++ b/examples/udp_transport/main.go
@@ -85,7 +85,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 
-	res, err := transport.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, false)
+	res, err := transport.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov)
 	if err != nil {
 		log.Fatalf("call: %v", err)
 	}

--- a/examples/webrtc_client/main.go
+++ b/examples/webrtc_client/main.go
@@ -211,7 +211,7 @@ func main() {
 	}
 
 	log.Println("Attempting to call echo tool...")
-	res, err := client.CallTool(ctx, "webrtc.echo", map[string]any{"msg": "Hello, WebRTC!"}, true)
+	res, err := client.CallTool(ctx, "webrtc.echo", map[string]any{"msg": "Hello, WebRTC!"})
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/webrtc_transport/main.go
+++ b/examples/webrtc_transport/main.go
@@ -120,7 +120,7 @@ func main() {
 		log.Printf(" - %s", t.Name)
 	}
 	// call echo
-	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "Hello, WebRTC!"}, prov, true)
+	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "Hello, WebRTC!"}, prov)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/websocket_client/main.go
+++ b/examples/websocket_client/main.go
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	// Call the streaming tool
-	res, err := client.CallTool(ctx, "websocket.multipleChunks", map[string]any{}, true)
+	res, err := client.CallTool(ctx, "websocket.multipleChunks", map[string]any{})
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/examples/websocket_transport/main.go
+++ b/examples/websocket_transport/main.go
@@ -71,7 +71,7 @@ func main() {
 		log.Printf(" - %s: %s", t.Name, t.Description)
 	}
 
-	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hello"}, prov, true)
+	res, err := transport.CallTool(ctx, "echo", map[string]any{"msg": "hello"}, prov)
 	if err != nil {
 		log.Fatalf("call error: %v", err)
 	}

--- a/parse_and_process_test.go
+++ b/parse_and_process_test.go
@@ -20,7 +20,7 @@ func (m *miniTransport) RegisterToolProvider(ctx context.Context, prov Provider)
 	return []Tool{{Name: "x"}}, nil
 }
 func (m *miniTransport) DeregisterToolProvider(ctx context.Context, prov Provider) error { return nil }
-func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (m *miniTransport) CallTool(ctx context.Context, tool string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	return nil, errors.ErrUnsupported
 }
 

--- a/src/providers/base/providers.go
+++ b/src/providers/base/providers.go
@@ -31,3 +31,7 @@ type BaseProvider struct {
 func (b *BaseProvider) Type() ProviderType {
 	return b.ProviderType
 }
+
+type CallingOptions struct {
+	Stream bool `json:"streaming"`
+}

--- a/src/providers/base/providers.go
+++ b/src/providers/base/providers.go
@@ -33,5 +33,5 @@ func (b *BaseProvider) Type() ProviderType {
 }
 
 type CallingOptions struct {
-	Stream bool `json:"streaming"`
+	Stream bool
 }

--- a/src/repository/client_transport_interface.go
+++ b/src/repository/client_transport_interface.go
@@ -18,5 +18,5 @@ type ClientTransport interface {
 
 	// CallTool invokes a named tool with the given arguments on a specific provider.
 	// It returns whatever the tool returns (often map[string]interface{} or a typed result).
-	CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, stream bool) (any, error)
+	CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, options ...CallingOptions) (any, error)
 }

--- a/src/transports/cli/cli_transport.go
+++ b/src/transports/cli/cli_transport.go
@@ -203,7 +203,7 @@ func (t *CliTransport) CallTool(
 	toolName string,
 	args map[string]interface{},
 	prov Provider,
-	stream bool,
+	options ...CallingOptions,
 ) (interface{}, error) {
 	cliProv, ok := prov.(*CliProvider)
 	if !ok || cliProv.CommandName == "" {

--- a/src/transports/cli/cli_transport_register_call_test.go
+++ b/src/transports/cli/cli_transport_register_call_test.go
@@ -27,7 +27,7 @@ func TestCliTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("register error %v tools %v", err, tools)
 	}
 
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{}, prov, false)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport.go
+++ b/src/transports/graphql/graphql_transport.go
@@ -328,7 +328,7 @@ func (t *GraphQLClientTransport) DeregisterToolProvider(ctx context.Context, man
 }
 
 // CallTool executes a GraphQL operation by name with proper type support.
-func (t *GraphQLClientTransport) CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, stream bool) (any, error) {
+func (t *GraphQLClientTransport) CallTool(ctx context.Context, toolName string, arguments map[string]any, toolProvider Provider, options ...CallingOptions) (any, error) {
 	prov, ok := toolProvider.(*GraphQLProvider)
 	if !ok {
 		return nil, errors.New("GraphQLClientTransport can only be used with GraphQLProvider")

--- a/src/transports/graphql/graphql_transport_additional_test.go
+++ b/src/transports/graphql/graphql_transport_additional_test.go
@@ -120,14 +120,14 @@ func TestGraphQL_RegisterAndCall_Errors(t *testing.T) {
 	if _, err := tr.RegisterToolProvider(ctx, &CliProvider{}); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
-	if _, err := tr.CallTool(ctx, "x", nil, &CliProvider{}, false); err == nil {
+	if _, err := tr.CallTool(ctx, "x", nil, &CliProvider{}); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
 	prov := &GraphQLProvider{URL: "http://example.com"}
 	if _, err := tr.RegisterToolProvider(ctx, prov); err == nil {
 		t.Fatalf("expected https enforcement error")
 	}
-	if _, err := tr.CallTool(ctx, "foo", nil, prov, false); err == nil {
+	if _, err := tr.CallTool(ctx, "foo", nil, prov); err == nil {
 		t.Fatalf("expected https enforcement error")
 	}
 }
@@ -140,7 +140,7 @@ func TestGraphQL_CallTool_NoData(t *testing.T) {
 	defer server.Close()
 	prov := &GraphQLProvider{URL: server.URL}
 	tr := NewGraphQLClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "foo", nil, prov, false)
+	res, err := tr.CallTool(context.Background(), "foo", nil, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport_subscription_test.go
+++ b/src/transports/graphql/graphql_transport_subscription_test.go
@@ -75,7 +75,7 @@ func TestGraphQLClientTransport_OperationType(t *testing.T) {
 
 	prov := &GraphQLProvider{URL: server.URL, OperationType: "subscription"}
 	tr := NewGraphQLClientTransport(nil)
-	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, false); err != nil {
+	if _, err := tr.CallTool(context.Background(), "ok", nil, prov); err != nil {
 		t.Fatalf("call error: %v", err)
 	}
 	if !strings.HasPrefix(gotQuery, "subscription ") {
@@ -83,7 +83,7 @@ func TestGraphQLClientTransport_OperationType(t *testing.T) {
 	}
 
 	prov.OperationType = "mutation"
-	if _, err := tr.CallTool(context.Background(), "ok", nil, prov, false); err != nil {
+	if _, err := tr.CallTool(context.Background(), "ok", nil, prov); err != nil {
 		t.Fatalf("call error: %v", err)
 	}
 	if !strings.HasPrefix(gotQuery, "mutation ") {

--- a/src/transports/graphql/graphql_transport_test.go
+++ b/src/transports/graphql/graphql_transport_test.go
@@ -52,7 +52,7 @@ func TestGraphQLClientTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("expected 1 tool, got %d: %+v", len(tools), tools)
 	}
 
-	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{"name": "bob"}, prov, false)
+	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{"name": "bob"}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/graphql/graphql_transport_websocket_test.go
+++ b/src/transports/graphql/graphql_transport_websocket_test.go
@@ -51,7 +51,7 @@ func TestGraphQLClientTransport_WebSocketSubscription(t *testing.T) {
 
 	prov := &GraphQLProvider{BaseProvider: BaseProvider{ProviderType: ProviderGraphQL}, URL: wsURL, OperationType: "subscription"}
 	tr := NewGraphQLClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "updates", nil, prov, false)
+	res, err := tr.CallTool(context.Background(), "updates", nil, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/grpc/grpc_transport.go
+++ b/src/transports/grpc/grpc_transport.go
@@ -75,7 +75,7 @@ func (t *GRPCClientTransport) DeregisterToolProvider(ctx context.Context, prov P
 }
 
 // CallTool invokes the CallTool RPC on the UTCPService.
-func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (t *GRPCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	gp, ok := prov.(*GRPCProvider)
 	if !ok {
 		return nil, errors.New("GRPCClientTransport can only be used with GRPCProvider")

--- a/src/transports/grpc/grpc_transport_test.go
+++ b/src/transports/grpc/grpc_transport_test.go
@@ -51,7 +51,7 @@ func TestGRPCTransport_RegisterAndCall(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "ping" {
 		t.Fatalf("register error: %v tools:%v", err, tools)
 	}
-	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, false)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestGRPCTransport_Errors(t *testing.T) {
 	if err := tr.DeregisterToolProvider(context.Background(), &HttpProvider{}); err == nil {
 		t.Fatal("expected type error")
 	}
-	if _, err := tr.CallTool(context.Background(), "ping", nil, &HttpProvider{}, false); err == nil {
+	if _, err := tr.CallTool(context.Background(), "ping", nil, &HttpProvider{}); err == nil {
 		t.Fatal("expected type error")
 	}
 }

--- a/src/transports/http/http_transport.go
+++ b/src/transports/http/http_transport.go
@@ -198,7 +198,7 @@ func (t *HttpClientTransport) RegisterToolProvider(ctx context.Context, p Provid
 }
 
 // CallTool calls a specific tool on the HTTP provider.
-func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, p Provider, stream bool) (any, error) {
+func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, p Provider, options ...CallingOptions) (any, error) {
 	hp, ok := p.(*HttpProvider)
 	if !ok {
 		return nil, errors.New("HttpTransport can only be used with HttpProvider")

--- a/src/transports/http/http_transport_additional_test.go
+++ b/src/transports/http/http_transport_additional_test.go
@@ -25,7 +25,7 @@ func TestHttpTransport_CallTool_Error(t *testing.T) {
 	defer server.Close()
 	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL}
 	tr := NewHttpClientTransport(nil)
-	_, err := tr.CallTool(context.Background(), "t", map[string]any{}, prov, false)
+	_, err := tr.CallTool(context.Background(), "t", map[string]any{}, prov)
 	if err == nil {
 		t.Fatalf("expected error from call")
 	}
@@ -41,7 +41,7 @@ func TestHttpTransport_CallTool_PathSub(t *testing.T) {
 	defer server.Close()
 	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL + "/{id}"}
 	tr := NewHttpClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov, false)
+	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/http/http_transport_test.go
+++ b/src/transports/http/http_transport_test.go
@@ -42,7 +42,7 @@ func TestHttpClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL + "/ping"
-	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, false)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -241,13 +241,17 @@ func (t *MCPTransport) CallTool(
 	toolName string,
 	args map[string]any,
 	p Provider,
-	options ...CallingOptions,
+	opts ...CallingOptions,
 ) (interface{}, error) {
 	mp, ok := p.(*MCPProvider)
 	if !ok {
 		return nil, errors.New("MCPTransport can only be used with MCPProvider")
 	}
-
+	// 7. Debug log to confirm opts arrived
+	if len(opts) == 0 {
+		// populate with a “zero” option, or whatever default makes sense
+		opts = []CallingOptions{{}}
+	}
 	// Lookup the process for this provider
 	t.mutex.RLock()
 	proc, exists := t.processes[mp.Name]
@@ -260,7 +264,7 @@ func (t *MCPTransport) CallTool(
 	var res interface{}
 	var err error
 	switch {
-	case options[0].Stream == true:
+	case opts[0].Stream == true:
 		res, err = t.CallToolStream(ctx, toolName, args, p)
 	case proc.httpClient != nil:
 		// HTTP‑capable synchronous tools

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -241,7 +241,7 @@ func (t *MCPTransport) CallTool(
 	toolName string,
 	args map[string]any,
 	p Provider,
-	stream bool,
+	options ...CallingOptions,
 ) (interface{}, error) {
 	mp, ok := p.(*MCPProvider)
 	if !ok {
@@ -259,9 +259,8 @@ func (t *MCPTransport) CallTool(
 	// Dispatch based on tool capabilities
 	var res interface{}
 	var err error
-
 	switch {
-	case stream == true:
+	case options[0].Stream == true:
 		res, err = t.CallToolStream(ctx, toolName, args, p)
 	case proc.httpClient != nil:
 		// HTTP‑capable synchronous tools

--- a/src/transports/mcp/mcp_transport_additional_test.go
+++ b/src/transports/mcp/mcp_transport_additional_test.go
@@ -5,6 +5,7 @@ import (
 
 	"testing"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
 )
@@ -22,7 +23,9 @@ func TestMCPTransport_Errors(t *testing.T) {
 		t.Fatalf("expected error for wrong provider")
 	}
 	// wrong provider for call
-	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, false); err == nil {
+	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, base.CallingOptions{
+		Stream: false,
+	}); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
 	// proper provider succeeds
@@ -30,7 +33,9 @@ func TestMCPTransport_Errors(t *testing.T) {
 	if _, err := tr.RegisterToolProvider(ctx, prov); err != nil {
 		t.Fatalf("register err: %v", err)
 	}
-	if res, err := tr.CallTool(ctx, "hello", nil, prov, false); err != nil {
+	if res, err := tr.CallTool(ctx, "hello", nil, prov, base.CallingOptions{
+		Stream: false,
+	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if res == nil {
 		t.Fatalf("expected non-nil result")

--- a/src/transports/mcp/mcp_transport_http_test.go
+++ b/src/transports/mcp/mcp_transport_http_test.go
@@ -12,6 +12,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cast"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
 	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 )
@@ -46,7 +47,9 @@ func TestMCPHTTPNonStreamReturnsMap(t *testing.T) {
 		t.Fatalf("register err: %v", err)
 	}
 
-	res, err := tr.CallTool(ctx, "hello", map[string]any{"name": "Go"}, prov, false)
+	res, err := tr.CallTool(ctx, "hello", map[string]any{"name": "Go"}, prov, base.CallingOptions{
+		Stream: false,
+	})
 	if err != nil {
 		t.Fatalf("call err: %v", err)
 	}

--- a/src/transports/mcp/mcp_transport_test.go
+++ b/src/transports/mcp/mcp_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
 )
 
@@ -20,7 +21,9 @@ func TestMCPClientTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("expected non-nil tools")
 	}
 
-	if res, err := tr.CallTool(ctx, "hello", nil, prov, false); err != nil {
+	if res, err := tr.CallTool(ctx, "hello", nil, prov, base.CallingOptions{
+		Stream: false,
+	}); err != nil {
 		t.Fatalf("call error: %v", err)
 	} else if res == nil {
 		t.Fatalf("expected non-nil result")

--- a/src/transports/sse/sse_client_transport.go
+++ b/src/transports/sse/sse_client_transport.go
@@ -79,7 +79,7 @@ func (t *SSEClientTransport) DeregisterToolProvider(ctx context.Context, prov Pr
 }
 
 // CallTool invokes a named tool, using SSE if available.
-func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args map[string]interface{}, prov Provider, stream bool) (interface{}, error) {
+func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args map[string]interface{}, prov Provider, options ...CallingOptions) (interface{}, error) {
 	sseProv, ok := prov.(*SSEProvider)
 	if !ok {
 		return nil, errors.New("SSEClientTransport can only be used with SSEProvider")

--- a/src/transports/sse/sse_client_transport_test.go
+++ b/src/transports/sse/sse_client_transport_test.go
@@ -44,7 +44,7 @@ func TestSSEClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi", "lastEventID": nil}, prov, false)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi", "lastEventID": nil}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/streamable/streamable_transport.go
+++ b/src/transports/streamable/streamable_transport.go
@@ -69,7 +69,7 @@ func (t *StreamableHTTPClientTransport) CallTool(
 	toolName string,
 	args map[string]interface{},
 	prov Provider,
-	stream bool,
+	options ...CallingOptions,
 ) (interface{}, error) {
 	streamProv, ok := prov.(*StreamableHttpProvider)
 	if !ok {
@@ -174,7 +174,7 @@ func (t *StreamableHTTPClientTransport) CallToolStream(
 	toolName string,
 	args map[string]interface{},
 	prov Provider) (transports.StreamResult, error) {
-	result, err := t.CallTool(ctx, toolName, args, prov, true)
+	result, err := t.CallTool(ctx, toolName, args, prov)
 	if err != nil {
 		return nil, err
 	}

--- a/src/transports/streamable/streamable_transport_test.go
+++ b/src/transports/streamable/streamable_transport_test.go
@@ -49,7 +49,7 @@ func TestStreamableHTTPClientTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = server.URL
-	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, true)
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/tcp/tcp_transport.go
+++ b/src/transports/tcp/tcp_transport.go
@@ -74,7 +74,7 @@ func (t *TCPClientTransport) DeregisterToolProvider(ctx context.Context, prov Pr
 }
 
 // CallTool connects to the provider and sends a tool invocation request.
-func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	tcpProv, ok := prov.(*TCPProvider)
 	if !ok {
 		return nil, errors.New("TCPClientTransport can only be used with TCPProvider")

--- a/src/transports/tcp/tcp_transport_test.go
+++ b/src/transports/tcp/tcp_transport_test.go
@@ -74,7 +74,7 @@ func TestTCPClientTransport_RegisterAndCall(t *testing.T) {
 	if len(tools) != 1 || tools[0].Name != "ping" {
 		t.Fatalf("unexpected tools: %+v", tools)
 	}
-	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, false)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/udp/udp_transport.go
+++ b/src/transports/udp/udp_transport.go
@@ -81,7 +81,7 @@ func (t *UDPTransport) DeregisterToolProvider(ctx context.Context, prov Provider
 }
 
 // CallTool sends a JSON request with tool name and arguments and waits for the response.
-func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	p, ok := prov.(*UDPProvider)
 	if !ok {
 		return nil, errors.New("UDPTransport can only be used with UDPProvider")

--- a/src/transports/udp/udp_transport_test.go
+++ b/src/transports/udp/udp_transport_test.go
@@ -89,7 +89,7 @@ func TestUDPTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("unexpected tools: %+v", tools)
 	}
 
-	res, err := tr.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, false)
+	res, err := tr.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/src/transports/webrtc/webrtc_transport.go
+++ b/src/transports/webrtc/webrtc_transport.go
@@ -173,7 +173,7 @@ func (t *WebRTCClientTransport) DeregisterToolProvider(ctx context.Context, prov
 	return nil
 }
 
-func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (t *WebRTCClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	if t.dc == nil {
 		return nil, errors.New("data channel not established")
 	}

--- a/src/transports/webrtc/webrtc_transport_integration_test.go
+++ b/src/transports/webrtc/webrtc_transport_integration_test.go
@@ -77,7 +77,7 @@ func TestWebRTCTransport_RegisterAndCall(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "echo" {
 		t.Fatalf("register: %v tools:%v", err, tools)
 	}
-	res, err := tr.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov, false)
+	res, err := tr.CallTool(ctx, "echo", map[string]any{"msg": "hi"}, prov)
 	if err != nil {
 		t.Fatalf("call: %v", err)
 	}

--- a/src/transports/websocket/websocket_transport.go
+++ b/src/transports/websocket/websocket_transport.go
@@ -102,7 +102,7 @@ func (t *WebSocketClientTransport) DeregisterToolProvider(ctx context.Context, p
 	return nil
 }
 
-func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (t *WebSocketClientTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	wsProv, ok := prov.(*WebSocketProvider)
 	if !ok {
 		return nil, errors.New("WebSocketClientTransport can only be used with WebSocketProvider")

--- a/src/transports/websocket/websocket_transport_additional_test.go
+++ b/src/transports/websocket/websocket_transport_additional_test.go
@@ -44,7 +44,7 @@ func TestWebSocketTransport_RegisterWrongType(t *testing.T) {
 
 func TestWebSocketTransport_CallWrongType(t *testing.T) {
 	tr := NewWebSocketTransport(nil)
-	_, err := tr.CallTool(context.Background(), "x", nil, &HttpProvider{}, false)
+	_, err := tr.CallTool(context.Background(), "x", nil, &HttpProvider{})
 	if err == nil {
 		t.Fatal("expected type error")
 	}

--- a/src/transports/websocket/websocket_transport_test.go
+++ b/src/transports/websocket/websocket_transport_test.go
@@ -59,7 +59,7 @@ func TestWebSocketTransport_RegisterAndCall(t *testing.T) {
 	}
 
 	prov.URL = wsURL
-	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov, false)
+	res, err := tr.CallTool(ctx, "ping", map[string]any{"msg": "hi"}, prov)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -48,7 +49,7 @@ import (
 type UtcpClientInterface interface {
 	RegisterToolProvider(ctx context.Context, prov Provider) ([]Tool, error)
 	DeregisterToolProvider(ctx context.Context, providerName string) error
-	CallTool(ctx context.Context, toolName string, args map[string]any, stream bool) (any, error)
+	CallTool(ctx context.Context, toolName string, args map[string]any, opts ...CallingOptions) (any, error)
 	SearchTools(query string, limit int) ([]Tool, error)
 	GetTransports() map[string]ClientTransport
 }
@@ -315,7 +316,7 @@ func (c *UtcpClient) CallTool(
 	ctx context.Context,
 	toolName string,
 	args map[string]any,
-	stream bool,
+	opts ...CallingOptions,
 ) (any, error) {
 	parts := strings.SplitN(toolName, ".", 2)
 	if len(parts) != 2 {
@@ -360,8 +361,9 @@ func (c *UtcpClient) CallTool(
 		// Strip provider prefix for MCP transport
 		callName = parts[1]
 	}
+	log.Println(opts)
 
-	return tr.CallTool(ctx, callName, args, *prov, stream)
+	return tr.CallTool(ctx, callName, args, *prov, opts...)
 }
 
 func (c *UtcpClient) SearchTools(query string, limit int) ([]Tool, error) {

--- a/utcp_client_additional_test.go
+++ b/utcp_client_additional_test.go
@@ -52,7 +52,7 @@ func (s *stubTransport) DeregisterToolProvider(ctx context.Context, prov Provide
 	return nil
 }
 
-func (s *stubTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, stream bool) (any, error) {
+func (s *stubTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, options ...CallingOptions) (any, error) {
 	s.callCalled = true
 	return "ok", nil
 }
@@ -164,7 +164,7 @@ func TestUtcpClientFlow(t *testing.T) {
 	if err != nil || len(tools) != 1 || tools[0].Name != "my_cli.echo" || !tr.registerCalled {
 		t.Fatalf("register failed: %v %v", tools, err)
 	}
-	if _, err := client.CallTool(ctx, "my_cli.echo", map[string]any{"a": 1}, false); err != nil || !tr.callCalled {
+	if _, err := client.CallTool(ctx, "my_cli.echo", map[string]any{"a": 1}); err != nil || !tr.callCalled {
 		t.Fatalf("call failed: %v", err)
 	}
 	res, err := client.SearchTools("my_cli", 10)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced the stream boolean argument in CallTool methods with a CallingOptions struct to support more flexible tool call options across all transports and clients.

- **Refactors**
  - Updated all CallTool signatures and usages to accept CallingOptions instead of a stream boolean.
  - Adjusted related tests and examples to use the new CallingOptions pattern.

<!-- End of auto-generated description by cubic. -->

