### PR TITLE
docs: add example overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In contrast to other protocols like MCP, UTCP places a strong emphasis on:
 
 ### Examples
 
-Each subdirectory under `examples/` is a standalone Go module. When
+Each subdirectory under `examples/` is a standalone Go module demonstrating a client or transport. For an overview of available examples and usage instructions, see [examples/README.md](examples/README.md). When
 building or running an example from this repository, disable the
 workspace to ensure Go uses the module's own `go.mod`:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Examples
+
+This directory contains standalone Go modules that demonstrate how to use the UTCP client and transports.
+
+## Running an example
+
+From the repository root, disable the workspace so each example uses its own `go.mod`:
+
+```sh
+GOWORK=off go run ./examples/cli_transport
+```
+
+Replace `cli_transport` with the directory of the example you want to run.
+
+## Client examples
+
+- `cli_client`: Connects to tools exposed over the command line.
+- `graphql_client`: Calls tools provided via a GraphQL service.
+- `grpc_client`: Uses the gRPC transport.
+- `http_client`: Interacts with an HTTP provider.
+- `mcp_client`: Talks to a provider using the MCP transport.
+- `mcp_http_client`: Demonstrates the MCP HTTP transport.
+- `sse_client`: Streams results with Server-Sent Events.
+- `streamable_client`: Uses the streaming HTTP transport.
+- `tcp_client`: Communicates over a raw TCP connection.
+- `udp_client`: Sends requests over UDP.
+- `websocket_client`: Uses a WebSocket connection.
+- `webrtc_client`: Connects via WebRTC.
+
+## Transport examples
+
+- `cli_transport`: Exposes tools via the command line.
+- `graphql_transport`: Serves tools through a GraphQL endpoint.
+- `grpc_transport`: Implements a gRPC provider.
+- `http_transport`: Serves tools over HTTP.
+- `mcp_transport`: Bridges UTCP to the MCP protocol.
+- `mcp_http_transport`: Bridges UTCP to MCP over HTTP.
+- `sse_transport`: Sends results using Server-Sent Events.
+- `streamable_transport`: Demonstrates the streaming HTTP transport.
+- `tcp_transport`: Provides tools over TCP.
+- `udp_transport`: Provides tools over UDP.
+- `websocket_transport`: Hosts tools on a WebSocket server.
+- `webrtc_transport`: Serves tools using WebRTC.
+


### PR DESCRIPTION
## Summary
- document example clients and transports
- link root README to the example overview

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f6b66db588322b9a6b6572cb552b0