### PR TITLE
support openapi v2 in converter

### DIFF
--- a/src/openapi/open_api_converter_oas2_test.go
+++ b/src/openapi/open_api_converter_oas2_test.go
@@ -1,0 +1,65 @@
+package openapi
+
+import (
+	"testing"
+
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
+)
+
+func TestConvert_OAS2(t *testing.T) {
+	spec := map[string]interface{}{
+		"swagger":  "2.0",
+		"info":     map[string]interface{}{"title": "Test API"},
+		"schemes":  []interface{}{"https"},
+		"host":     "api.example.com",
+		"basePath": "/v1",
+		"paths": map[string]interface{}{
+			"/ping": map[string]interface{}{
+				"post": map[string]interface{}{
+					"operationId": "ping",
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":     "payload",
+							"in":       "body",
+							"required": true,
+							"schema": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"id": map[string]interface{}{"type": "string"},
+								},
+							},
+						},
+					},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							"description": "ok",
+							"schema": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"success": map[string]interface{}{"type": "boolean"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := NewConverter(spec, "", "")
+	manual := c.Convert()
+	if len(manual.Tools) != 1 {
+		t.Fatalf("expected one tool, got %d", len(manual.Tools))
+	}
+	tool := manual.Tools[0]
+	hp := tool.Provider.(*HttpProvider)
+	if hp.URL != "https://api.example.com/v1/ping" {
+		t.Fatalf("unexpected URL: %s", hp.URL)
+	}
+	if hp.BodyField == nil || *hp.BodyField != "payload" {
+		t.Fatalf("expected body field 'payload', got %v", hp.BodyField)
+	}
+	if tool.Outputs.Properties["success"] == nil {
+		t.Fatalf("expected output property 'success'")
+	}
+}


### PR DESCRIPTION
## Summary
- enable base URL detection using `host`/`schemes`/`basePath`
- recognize `in: body` parameters and classic `schema` responses
- add regression test for Swagger 2 conversions

## Testing
- `go test ./src/openapi -run Test -v`
- `go test ./src/... -run Test -count=1`
- `go test -run Test -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6890f1aeb3548322afd38c953625551f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for OpenAPI v2 (Swagger 2.0) in the converter, including base URL detection and handling of body parameters and schema responses.

- **Testing**
  - Added a regression test to verify Swagger 2 conversions.

<!-- End of auto-generated description by cubic. -->

