### PR TITLE
Add text transport, provider, and examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Replace `cli_transport` with the directory of the example you want to run.
 - `udp_client`: Sends requests over UDP.
 - `websocket_client`: Uses a WebSocket connection.
 - `webrtc_client`: Connects via WebRTC.
+- `text_client`: Renders text templates locally.
 
 ## Transport examples
 
@@ -41,4 +42,5 @@ Replace `cli_transport` with the directory of the example you want to run.
 - `udp_transport`: Provides tools over UDP.
 - `websocket_transport`: Hosts tools on a WebSocket server.
 - `webrtc_transport`: Serves tools using WebRTC.
+- `text_transport`: Provides tools based on text templates.
 

--- a/examples/text_client/go.mod
+++ b/examples/text_client/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.23.0

--- a/examples/text_client/main.go
+++ b/examples/text_client/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	utcp "github.com/universal-tool-calling-protocol/go-utcp"
+)
+
+func main() {
+	ctx := context.Background()
+	cfg := &utcp.UtcpClientConfig{ProvidersFilePath: "provider.json"}
+	client, err := utcp.NewUTCPClient(ctx, cfg, nil, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "client error: %v\n", err)
+		os.Exit(1)
+	}
+	time.Sleep(100 * time.Millisecond)
+	res, err := client.CallTool(ctx, "greetings.hello", map[string]any{"name": "World"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "call error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Result: %v\n", res)
+}

--- a/examples/text_client/provider.json
+++ b/examples/text_client/provider.json
@@ -1,0 +1,9 @@
+[
+  {
+    "provider_type": "text",
+    "name": "greetings",
+    "templates": {
+      "hello": "Hello, {{.name}}!"
+    }
+  }
+]

--- a/examples/text_transport/go.mod
+++ b/examples/text_transport/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.23.0

--- a/examples/text_transport/main.go
+++ b/examples/text_transport/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
+	transport "github.com/universal-tool-calling-protocol/go-utcp/src/transports/text"
+)
+
+func main() {
+	ctx := context.Background()
+	t := transport.NewTextTransport(func(format string, args ...interface{}) {
+		fmt.Printf("[LOG] "+format+"\n", args...)
+	})
+	p := &providers.TextProvider{Templates: map[string]string{"hello": "Hello, {{.name}}"}}
+	tools, err := t.RegisterToolProvider(ctx, p)
+	if err != nil {
+		panic(err)
+	}
+	res, err := t.CallTool(ctx, tools[0].Name, map[string]any{"name": "UTCP"}, p, nil)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Result: %v\n", res)
+}

--- a/src/providers/base/providers.go
+++ b/src/providers/base/providers.go
@@ -14,6 +14,7 @@ const (
 	ProviderUDP        ProviderType = "udp"
 	ProviderWebRTC     ProviderType = "webrtc"
 	ProviderMCP        ProviderType = "mcp"
+	ProviderText       ProviderType = "text"
 )
 
 // Provider is implemented by all concrete provider types.

--- a/src/providers/helpers/unmarshal.go
+++ b/src/providers/helpers/unmarshal.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/sse"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/streamable"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/udp"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/websocket"
@@ -70,6 +71,8 @@ func UnmarshalProvider(data []byte) (Provider, error) {
 			return nil, err
 		}
 		return p, nil
+	case ProviderText:
+		return UnmarshalTextProvider(data)
 	default:
 		return nil, fmt.Errorf("unsupported provider_type %q", base.ProviderType)
 	}

--- a/src/providers/text/provider.go
+++ b/src/providers/text/provider.go
@@ -1,0 +1,24 @@
+package text
+
+import (
+	"encoding/json"
+
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+)
+
+// TextProvider represents a provider that serves text templates.
+type TextProvider struct {
+	BaseProvider
+	Templates map[string]string `json:"templates"`
+}
+
+func UnmarshalTextProvider(data []byte) (*TextProvider, error) {
+	p := &TextProvider{}
+	if err := json.Unmarshal(data, p); err != nil {
+		return nil, err
+	}
+	if p.ProviderType == "" {
+		p.ProviderType = ProviderText
+	}
+	return p, nil
+}

--- a/src/providers/text/provider_test.go
+++ b/src/providers/text/provider_test.go
@@ -1,0 +1,20 @@
+package text
+
+import (
+	"testing"
+
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+)
+
+func TestTextProvider_Basic(t *testing.T) {
+	p := &TextProvider{
+		BaseProvider: BaseProvider{Name: "txt", ProviderType: ProviderText},
+		Templates:    map[string]string{"hello": "Hello"},
+	}
+	if p.Type() != ProviderText {
+		t.Fatalf("Type mismatch")
+	}
+	if p.Templates["hello"] != "Hello" {
+		t.Fatalf("template not set")
+	}
+}

--- a/src/repository/repo.go
+++ b/src/repository/repo.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/sse"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/streamable"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/udp"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/websocket"
@@ -121,6 +122,8 @@ func (r *InMemoryToolRepository) SaveProviderWithTools(ctx context.Context, prov
 	case *WebRTCProvider:
 		providerName = p.Name
 	case *MCPProvider:
+		providerName = p.Name
+	case *TextProvider:
 		providerName = p.Name
 	default:
 		return fmt.Errorf("unsupported provider type for saving: %T", provider)

--- a/src/transports/text/text_transport.go
+++ b/src/transports/text/text_transport.go
@@ -1,0 +1,79 @@
+package text
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
+)
+
+// TextTransport executes tools defined as text templates.
+type TextTransport struct {
+	log      func(string, ...interface{})
+	basePath string
+}
+
+// NewTextTransport creates a new TextTransport.
+func NewTextTransport(logger func(string, ...interface{})) *TextTransport {
+	if logger == nil {
+		logger = func(string, ...interface{}) {}
+	}
+	return &TextTransport{log: logger}
+}
+
+// SetBasePath sets the base path for resolving files (unused but kept for compatibility).
+func (t *TextTransport) SetBasePath(path string) { t.basePath = path }
+
+// RegisterToolProvider generates tools from the provider's templates.
+func (t *TextTransport) RegisterToolProvider(ctx context.Context, manual Provider) ([]Tool, error) {
+	p, ok := manual.(*providers.TextProvider)
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider type %T", manual)
+	}
+	tools := make([]Tool, 0, len(p.Templates))
+	for name := range p.Templates {
+		tools = append(tools, Tool{
+			Name:        name,
+			Description: "Text template tool",
+			Inputs:      ToolInputOutputSchema{Type: "object"},
+			Outputs:     ToolInputOutputSchema{Type: "string"},
+		})
+	}
+	return tools, nil
+}
+
+// DeregisterToolProvider is a no-op for TextTransport.
+func (t *TextTransport) DeregisterToolProvider(ctx context.Context, manual Provider) error {
+	return nil
+}
+
+// CallTool renders the template with the provided arguments.
+func (t *TextTransport) CallTool(ctx context.Context, toolName string, args map[string]any, manual Provider, l *string) (any, error) {
+	p, ok := manual.(*providers.TextProvider)
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider type %T", manual)
+	}
+	tmplStr, ok := p.Templates[toolName]
+	if !ok {
+		return nil, fmt.Errorf("tool %s not found", toolName)
+	}
+	tpl, err := template.New(toolName).Parse(tmplStr)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, args); err != nil {
+		return nil, err
+	}
+	return buf.String(), nil
+}
+
+// CallToolStream is not supported for TextTransport.
+func (t *TextTransport) CallToolStream(ctx context.Context, toolName string, args map[string]any, p Provider) (transports.StreamResult, error) {
+	return nil, fmt.Errorf("streaming not supported")
+}

--- a/src/transports/text/text_transport_test.go
+++ b/src/transports/text/text_transport_test.go
@@ -1,0 +1,31 @@
+package text
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
+)
+
+func TestTextTransport(t *testing.T) {
+	tr := NewTextTransport(nil)
+	prov := &providers.TextProvider{
+		BaseProvider: BaseProvider{Name: "txt", ProviderType: ProviderText},
+		Templates:    map[string]string{"hello": "Hello, {{.name}}"},
+	}
+	tools, err := tr.RegisterToolProvider(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "hello" {
+		t.Fatalf("unexpected tools: %v", tools)
+	}
+	res, err := tr.CallTool(context.Background(), "hello", map[string]any{"name": "Bob"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	if res.(string) != "Hello, Bob" {
+		t.Fatalf("unexpected result %v", res)
+	}
+}

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/sse"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/streamable"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/tcp"
+	texttransport "github.com/universal-tool-calling-protocol/go-utcp/src/transports/text"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/udp"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/webrtc"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/transports/websocket"
@@ -39,6 +40,7 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/sse"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/streamable"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/udp"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/websocket"
@@ -196,6 +198,9 @@ func defaultTransports() map[string]ClientTransport {
 		"webrtc": NewWebRTCClientTransport(func(format string, args ...interface{}) {
 			fmt.Printf("WebRTC Transport: "+format+"\n", args...)
 		}),
+		"text": texttransport.NewTextTransport(func(format string, args ...interface{}) {
+			fmt.Printf("Text Transport: "+format+"\n", args...)
+		}),
 	}
 }
 
@@ -255,6 +260,8 @@ func (c *UtcpClient) getProviderName(prov Provider) string {
 		return p.Name
 	case *MCPProvider:
 		return p.Name
+	case *TextProvider:
+		return p.Name
 	default:
 		return "unknown"
 	}
@@ -284,6 +291,8 @@ func (c *UtcpClient) setProviderName(prov Provider, name string) {
 	case *WebRTCProvider:
 		p.Name = name
 	case *MCPProvider:
+		p.Name = name
+	case *TextProvider:
 		p.Name = name
 	}
 }


### PR DESCRIPTION
## Summary
- add text provider type and template-based transport
- wire text transport into UTCP client and repository
- provide example programs for text client and transport

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ede9eda788322b6e820ca3398770f