### PR TITLE
feat(grpc): support gNMI basic auth and subscription modes

### DIFF
--- a/examples/grpc_gnmi_client/main.go
+++ b/examples/grpc_gnmi_client/main.go
@@ -27,7 +27,7 @@ const (
 	pass = "secret"
 )
 
-func checkCreds(ctx context.Context) error {
+func authFromContext(ctx context.Context) error {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return fmt.Errorf("missing metadata")
@@ -40,17 +40,25 @@ func checkCreds(ctx context.Context) error {
 	return nil
 }
 
-func (s *UnifiedServer) Capabilities(ctx context.Context, req *gnmi.CapabilityRequest) (*gnmi.CapabilityResponse, error) {
-	if err := checkCreds(ctx); err != nil {
+func unaryAuthInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if err := authFromContext(ctx); err != nil {
 		return nil, err
 	}
+	return handler(ctx, req)
+}
+
+func streamAuthInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	if err := authFromContext(ss.Context()); err != nil {
+		return err
+	}
+	return handler(srv, ss)
+}
+
+func (s *UnifiedServer) Capabilities(ctx context.Context, req *gnmi.CapabilityRequest) (*gnmi.CapabilityResponse, error) {
 	return &gnmi.CapabilityResponse{}, nil
 }
 
 func (s *UnifiedServer) GetManual(ctx context.Context, e *grpcpb.Empty) (*grpcpb.Manual, error) {
-	if err := checkCreds(ctx); err != nil {
-		return nil, err
-	}
 	return &grpcpb.Manual{
 		Version: "1.2",
 		Tools: []*grpcpb.Tool{
@@ -60,9 +68,6 @@ func (s *UnifiedServer) GetManual(ctx context.Context, e *grpcpb.Empty) (*grpcpb
 }
 
 func (s *UnifiedServer) CallTool(ctx context.Context, req *grpcpb.ToolCallRequest) (*grpcpb.ToolCallResponse, error) {
-	if err := checkCreds(ctx); err != nil {
-		return nil, err
-	}
 	// Simple implementation - could be expanded based on tool name
 	return &grpcpb.ToolCallResponse{
 		ResultJson: `{"status": "not implemented for non-streaming"}`,
@@ -71,10 +76,6 @@ func (s *UnifiedServer) CallTool(ctx context.Context, req *grpcpb.ToolCallReques
 
 func (s *UnifiedServer) CallToolStream(req *grpcpb.ToolCallRequest, stream grpcpb.UTCPService_CallToolStreamServer) error {
 	ctx := stream.Context()
-
-	if err := checkCreds(ctx); err != nil {
-		return err
-	}
 
 	if req.Tool == "gnmi_subscribe" {
 		// Parse args from JSON
@@ -132,10 +133,6 @@ func (s *UnifiedServer) CallToolStream(req *grpcpb.ToolCallRequest, stream grpcp
 
 func (s *UnifiedServer) Subscribe(stream gnmi.GNMI_SubscribeServer) error {
 	ctx := stream.Context()
-
-	if err := checkCreds(ctx); err != nil {
-		return err
-	}
 
 	// Single-sender to keep gRPC Send safe.
 	out := make(chan *gnmi.SubscribeResponse, 32)
@@ -244,7 +241,10 @@ func startGNMIServer(addr string) *grpc.Server {
 	if err != nil {
 		log.Fatalf("listen: %v", err)
 	}
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.UnaryInterceptor(unaryAuthInterceptor),
+		grpc.StreamInterceptor(streamAuthInterceptor),
+	)
 	gnmi.RegisterGNMIServer(srv, &UnifiedServer{})
 	grpcpb.RegisterUTCPServiceServer(srv, &UnifiedServer{})
 	go srv.Serve(lis)

--- a/examples/grpc_gnmi_client/provider.json
+++ b/examples/grpc_gnmi_client/provider.json
@@ -6,7 +6,12 @@
       "host": "127.0.0.1",
       "port": 9339,
       "service_name": "gnmi.gNMI",
-      "method_name": "Subscribe"
+      "method_name": "Subscribe",
+      "auth": {
+        "auth_type": "basic",
+        "username": "alice",
+        "password": "secret"
+      }
     }
   ]
 }

--- a/src/transports/grpc/grpc_transport_additional_test.go
+++ b/src/transports/grpc/grpc_transport_additional_test.go
@@ -1,0 +1,45 @@
+package grpc
+
+import (
+	"testing"
+
+	gnmi "github.com/openconfig/gnmi/proto/gnmi"
+	provgrpc "github.com/universal-tool-calling-protocol/go-utcp/src/providers/grpc"
+)
+
+func TestParseGNMIPath(t *testing.T) {
+	p := parseGNMIPath("/interfaces/interface[name=Ethernet2][subif=0]/state/oper-status")
+	if len(p.GetElem()) != 4 {
+		t.Fatalf("expected 4 elems, got %d", len(p.GetElem()))
+	}
+	if p.GetElem()[1].GetName() != "interface" {
+		t.Fatalf("unexpected second element name: %s", p.GetElem()[1].GetName())
+	}
+	if p.GetElem()[1].GetKey()["name"] != "Ethernet2" || p.GetElem()[1].GetKey()["subif"] != "0" {
+		t.Fatalf("unexpected keys: %v", p.GetElem()[1].GetKey())
+	}
+}
+
+func TestBuildSubscribeRequest_SubMode(t *testing.T) {
+	tpt := NewGRPCClientTransport(nil)
+	gp := &provgrpc.GRPCProvider{}
+	args := map[string]any{
+		"path":     "/interfaces/interface[name=eth0]/state/oper-status",
+		"mode":     "STREAM",
+		"sub_mode": "ON_CHANGE",
+	}
+	req, err := tpt.buildSubscribeRequest(args, gp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sub := req.GetSubscribe().GetSubscription()
+	if len(sub) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(sub))
+	}
+	if sub[0].Mode != gnmi.SubscriptionMode_ON_CHANGE {
+		t.Fatalf("expected sub mode ON_CHANGE, got %v", sub[0].Mode)
+	}
+	if req.GetSubscribe().Mode != gnmi.SubscriptionList_STREAM {
+		t.Fatalf("expected list mode STREAM, got %v", req.GetSubscribe().Mode)
+	}
+}


### PR DESCRIPTION
## Summary by cubic
Adds Basic Auth to the gRPC transport and expands gNMI Subscribe support (list and per-subscription modes, intervals). Also improves gNMI path parsing with key predicates and updates examples and tests.

- **New Features**
  - gRPC Basic Auth: attach username/password via per-RPC metadata; respects TLS setting; provider.json and examples updated.
  - gNMI Subscribe: supports list modes ONCE/POLL/STREAM and sub modes SAMPLE/ON_CHANGE/TARGET_DEFINED.
  - Intervals/flags: accepts sample_interval_ns, heartbeat_interval_ns, suppress_redundant.
  - gNMI paths: parse elements with keys like /interfaces/interface[name=eth0]/state/... into Path.Elem with Key.
  - Examples/tests: example servers enforce creds; clients show auth and subscription options; added tests for path parsing and sub mode.

<!-- End of auto-generated description by cubic. -->

