### PR TITLE
Add agent-to-agent swarm coordination example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Replace `cli_transport` with the directory of the example you want to run.
 
 ## Client examples
 
+- `agent_swarm`: Demonstrates agent-to-agent coordination where a coordinator chains UTCP tools from multiple workers to build a swarm action plan.
 - `cli_client`: Connects to tools exposed over the command line.
 - `graphql_client`: Calls tools provided via a GraphQL service.
 - `grpc_client`: Uses the gRPC transport.

--- a/examples/agent_swarm/go.mod
+++ b/examples/agent_swarm/go.mod
@@ -1,0 +1,7 @@
+module main
+
+go 1.23.0
+
+require github.com/universal-tool-calling-protocol/go-utcp v0.0.0
+
+replace github.com/universal-tool-calling-protocol/go-utcp => ../..

--- a/examples/agent_swarm/main.go
+++ b/examples/agent_swarm/main.go
@@ -1,0 +1,506 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	base "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	providers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
+	transports "github.com/universal-tool-calling-protocol/go-utcp/src/transports/http"
+)
+
+type location struct {
+	ID       string
+	Signal   float64
+	Terrain  string
+	Resource string
+	Risk     float64
+}
+
+type evaluation struct {
+	ID                string
+	Score             float64
+	Confidence        float64
+	RecommendedAction string
+	SupportAgents     []string
+}
+
+func main() {
+	scoutServer := startScoutServer(":9081")
+	defer shutdownServer("scout", scoutServer)
+
+	analystServer := startAnalystServer(":9082")
+	defer shutdownServer("analyst", analystServer)
+
+	// Give the HTTP servers a moment to boot before running the swarm coordinator.
+	time.Sleep(250 * time.Millisecond)
+
+	logger := func(format string, args ...interface{}) {
+		log.Printf(format, args...)
+	}
+	transport := transports.NewHttpClientTransport(logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Discover tools from both worker agents.
+	scoutManual := &providers.HttpProvider{
+		BaseProvider: base.BaseProvider{Name: "scout-manual", ProviderType: base.ProviderHTTP},
+		URL:          "http://localhost:9081/tools",
+		HTTPMethod:   http.MethodGet,
+		Headers:      map[string]string{"Accept": "application/json"},
+	}
+	scoutTools, err := transport.RegisterToolProvider(ctx, scoutManual)
+	if err != nil {
+		log.Fatalf("failed to register scout provider: %v", err)
+	}
+	log.Printf("Scout agent exposes %d tool(s)", len(scoutTools))
+	for _, t := range scoutTools {
+		log.Printf(" • %s — %s", t.Name, t.Description)
+	}
+
+	analystManual := &providers.HttpProvider{
+		BaseProvider: base.BaseProvider{Name: "analyst-manual", ProviderType: base.ProviderHTTP},
+		URL:          "http://localhost:9082/tools",
+		HTTPMethod:   http.MethodGet,
+		Headers:      map[string]string{"Accept": "application/json"},
+	}
+	analystTools, err := transport.RegisterToolProvider(ctx, analystManual)
+	if err != nil {
+		log.Fatalf("failed to register analyst provider: %v", err)
+	}
+	log.Printf("Analyst agent exposes %d tool(s)", len(analystTools))
+	for _, t := range analystTools {
+		log.Printf(" • %s — %s", t.Name, t.Description)
+	}
+
+	// Coordinate the swarm by chaining tool calls between the agents.
+	plan, err := orchestrateSwarm(ctx, transport)
+	if err != nil {
+		log.Fatalf("swarm coordination failed: %v", err)
+	}
+
+	rendered, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		log.Fatalf("failed to render plan: %v", err)
+	}
+	fmt.Println("\nFinal swarm plan:")
+	fmt.Println(string(rendered))
+}
+
+func orchestrateSwarm(ctx context.Context, transport *transports.HttpClientTransport) (map[string]any, error) {
+	scoutCall := &providers.HttpProvider{
+		BaseProvider: base.BaseProvider{Name: "scout-call", ProviderType: base.ProviderHTTP},
+		URL:          "http://localhost:9081/tools/scan-terrain/call",
+		HTTPMethod:   http.MethodPost,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+	}
+
+	const region = "oasis-basin"
+	scanResult, err := transport.CallTool(ctx, "scan-terrain", map[string]any{"region": region}, scoutCall, nil)
+	if err != nil {
+		return nil, fmt.Errorf("scout scan failed: %w", err)
+	}
+
+	locations, err := parseLocations(scanResult)
+	if err != nil {
+		return nil, err
+	}
+	if len(locations) == 0 {
+		return nil, errors.New("scout agent did not discover any locations")
+	}
+
+	analystCall := &providers.HttpProvider{
+		BaseProvider: base.BaseProvider{Name: "analyst-call", ProviderType: base.ProviderHTTP},
+		URL:          "http://localhost:9082/tools/evaluate-location/call",
+		HTTPMethod:   http.MethodPost,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+	}
+
+	evaluations := make([]evaluation, 0, len(locations))
+	var evalMu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, loc := range locations {
+		loc := loc
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			payload := map[string]any{"location": map[string]any{
+				"id":       loc.ID,
+				"signal":   loc.Signal,
+				"terrain":  loc.Terrain,
+				"resource": loc.Resource,
+				"risk":     loc.Risk,
+			}}
+			res, err := transport.CallTool(ctx, "evaluate-location", payload, analystCall, nil)
+			if err != nil {
+				errOnce.Do(func() { firstErr = fmt.Errorf("analyst evaluation failed for %s: %w", loc.ID, err) })
+				return
+			}
+			eval, err := parseEvaluation(res)
+			if err != nil {
+				errOnce.Do(func() { firstErr = fmt.Errorf("invalid evaluation for %s: %w", loc.ID, err) })
+				return
+			}
+
+			evalMu.Lock()
+			evaluations = append(evaluations, eval)
+			evalMu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	if len(evaluations) == 0 {
+		return nil, errors.New("no evaluations returned by analyst agent")
+	}
+
+	sort.SliceStable(evaluations, func(i, j int) bool {
+		return evaluations[i].Score > evaluations[j].Score
+	})
+
+	topTargets := evaluations
+	if len(topTargets) > 2 {
+		topTargets = topTargets[:2]
+	}
+
+	directives := []string{}
+	if len(topTargets) > 0 {
+		directives = append(directives, fmt.Sprintf("Deploy harvesters to %s with action '%s' (score %.2f, confidence %.2f)", topTargets[0].ID, topTargets[0].RecommendedAction, topTargets[0].Score, topTargets[0].Confidence))
+	}
+	if len(topTargets) > 1 {
+		directives = append(directives, fmt.Sprintf("Assign reconnaissance drones to %s for follow-up sweeps", topTargets[1].ID))
+	}
+	directives = append(directives, "Synchronize agent telemetry every 30s and rebalance squads if signal strength drops")
+
+	selected := make([]map[string]any, 0, len(topTargets))
+	for _, t := range topTargets {
+		selected = append(selected, map[string]any{
+			"id":                 t.ID,
+			"score":              round2(t.Score),
+			"confidence":         round2(t.Confidence),
+			"recommended_action": t.RecommendedAction,
+			"support_agents":     t.SupportAgents,
+		})
+	}
+
+	plan := map[string]any{
+		"region":           region,
+		"timestamp":        time.Now().UTC().Format(time.RFC3339),
+		"selected_targets": selected,
+		"swarm_directives": directives,
+		"participating_agents": []string{
+			"scout-delta", "analyst-omega", "coordinator-hub",
+		},
+	}
+
+	return plan, nil
+}
+
+func parseLocations(res any) ([]location, error) {
+	payload, ok := res.(map[string]any)
+	if !ok {
+		return nil, errors.New("unexpected response from scout agent")
+	}
+	result, ok := payload["result"].(map[string]any)
+	if !ok {
+		return nil, errors.New("scout agent response missing result payload")
+	}
+	rawLocations, ok := result["locations"].([]any)
+	if !ok {
+		return nil, errors.New("scout agent returned locations in unexpected format")
+	}
+
+	var locations []location
+	for _, raw := range rawLocations {
+		locMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := locMap["id"].(string)
+		terrain, _ := locMap["terrain"].(string)
+		resource, _ := locMap["resource"].(string)
+
+		loc := location{
+			ID:       id,
+			Signal:   getFloat(locMap["signal"]),
+			Terrain:  terrain,
+			Resource: resource,
+			Risk:     getFloat(locMap["risk"]),
+		}
+		locations = append(locations, loc)
+	}
+
+	return locations, nil
+}
+
+func parseEvaluation(res any) (evaluation, error) {
+	payload, ok := res.(map[string]any)
+	if !ok {
+		return evaluation{}, errors.New("unexpected response type from analyst agent")
+	}
+	result, ok := payload["result"].(map[string]any)
+	if !ok {
+		return evaluation{}, errors.New("analyst response missing result payload")
+	}
+
+	id, _ := result["id"].(string)
+	action, _ := result["recommended_action"].(string)
+	support := []string{}
+	if rawSupport, ok := result["support_agents"].([]any); ok {
+		for _, item := range rawSupport {
+			if name, ok := item.(string); ok {
+				support = append(support, name)
+			}
+		}
+	}
+
+	eval := evaluation{
+		ID:                id,
+		Score:             getFloat(result["score"]),
+		Confidence:        getFloat(result["confidence"]),
+		RecommendedAction: action,
+		SupportAgents:     support,
+	}
+	return eval, nil
+}
+
+func getFloat(v any) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case float32:
+		return float64(val)
+	case int:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case uint:
+		return float64(val)
+	case uint32:
+		return float64(val)
+	case uint64:
+		return float64(val)
+	default:
+		return 0
+	}
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+func startScoutServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, map[string]any{
+			"version": "1.0",
+			"tools": []map[string]any{
+				{
+					"name":        "scan-terrain",
+					"description": "Survey a region and report back interesting resource signals.",
+					"input_schema": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"region": map[string]any{
+								"type":        "string",
+								"description": "Region identifier to scan",
+							},
+						},
+					},
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/tools/scan-terrain/call", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Region string `json:"region"`
+		}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&req)
+		}
+		region := req.Region
+		if region == "" {
+			region = "unknown"
+		}
+
+		locations := []map[string]any{
+			{
+				"id":       "oasis-alpha",
+				"signal":   0.91,
+				"terrain":  "oasis",
+				"resource": "water",
+				"risk":     0.12,
+			},
+			{
+				"id":       "ridge-sierra",
+				"signal":   0.82,
+				"terrain":  "ridge",
+				"resource": "minerals",
+				"risk":     0.28,
+			},
+			{
+				"id":       "canyon-echo",
+				"signal":   0.74,
+				"terrain":  "canyon",
+				"resource": "energy",
+				"risk":     0.35,
+			},
+		}
+
+		respondJSON(w, map[string]any{
+			"result": map[string]any{
+				"region":    region,
+				"locations": locations,
+				"summary":   fmt.Sprintf("Detected %d promising signals in %s", len(locations), region),
+			},
+		})
+	})
+
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Printf("Scout agent listening on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("scout server error: %v", err)
+		}
+	}()
+
+	return srv
+}
+
+func startAnalystServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, map[string]any{
+			"version": "1.0",
+			"tools": []map[string]any{
+				{
+					"name":        "evaluate-location",
+					"description": "Score a scanned location and propose the best swarm action.",
+					"input_schema": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"location": map[string]any{
+								"type":        "object",
+								"description": "The location payload from the scout agent.",
+							},
+						},
+					},
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/tools/evaluate-location/call", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Location map[string]any `json:"location"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+		location := req.Location
+		id, _ := location["id"].(string)
+		signal := getFloat(location["signal"])
+		risk := getFloat(location["risk"])
+		resource, _ := location["resource"].(string)
+
+		baseScore := 0.6*signal + 0.25*(1-risk)
+		if resource == "water" {
+			baseScore += 0.08
+		}
+		if resource == "energy" {
+			baseScore += 0.04
+		}
+		score := math.Min(0.99, math.Max(0.0, baseScore))
+
+		confidence := math.Min(0.95, 0.55+signal*0.35-risk*0.15)
+
+		action := "survey"
+		switch {
+		case score >= 0.85:
+			action = "harvest"
+		case score >= 0.7:
+			action = "deploy"
+		case risk >= 0.4:
+			action = "monitor"
+		}
+
+		support := []string{"drone-a1", "bot-b4"}
+		if action == "harvest" {
+			support = []string{"harvester-h3", "guardian-g2"}
+		}
+
+		respondJSON(w, map[string]any{
+			"result": map[string]any{
+				"id":                 id,
+				"score":              score,
+				"confidence":         confidence,
+				"recommended_action": action,
+				"support_agents":     support,
+			},
+		})
+	})
+
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Printf("Analyst agent listening on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("analyst server error: %v", err)
+		}
+	}()
+
+	return srv
+}
+
+func respondJSON(w http.ResponseWriter, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func shutdownServer(name string, srv *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("error shutting down %s server: %v", name, err)
+	}
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,4 @@
+bitbucket.org/creachadair/stringset v0.0.14 h1:t1ejQyf8utS4GZV/4fM+1gvYucggZkfhb+tMobDxYOE=
 bitbucket.org/creachadair/stringset v0.0.14/go.mod h1:Ej8fsr6rQvmeMDf6CCWMWGb14H9mz8kmDgPPTdiVT0w=
 cel.dev/expr v0.23.0 h1:wUb94w6OYQS4uXraxo9U+wUAs9jT47Xvl4iPgAwM2ss=
 cel.dev/expr v0.23.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
@@ -8,6 +9,7 @@ cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQ
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
 github.com/Raezil/UTCP v1.1.9 h1:CYJigZtIM0r6MN8YdkXq2vBuoXah+j1+Kc9+hcqoH5c=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -27,20 +29,25 @@ github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JS
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
-github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
-github.com/graphql-go/handler v0.2.4/go.mod h1:gsQlb4gDvURR0bgN8vWQEh+s5vJALM2lYL3n3cf6OxQ=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/openconfig/goyang v1.6.0 h1:JjnPbLY1/y28VyTO67LsEV0TaLWNiZyDcsppGq4F4is=
 github.com/openconfig/goyang v1.6.0/go.mod h1:sdNZi/wdTZyLNBNfgLzmmbi7kISm7FskMDKKzMY+x1M=
+github.com/openconfig/grpctunnel v0.1.0 h1:EN99qtlExZczgQgp5ANnHRC/Rs62cAG+Tz2BQ5m/maM=
 github.com/openconfig/grpctunnel v0.1.0/go.mod h1:G04Pdu0pml98tdvXrvLaU+EBo3PxYfI9MYqpvdaEHLo=
+github.com/openconfig/ygot v0.29.20 h1:XHLpwCN91QuKc2LAvnEqtCmH8OuxgLlErDhrdl2mJw8=
 github.com/openconfig/ygot v0.29.20/go.mod h1:K8HbrPm/v8/emtGQ9+RsJXx6UPKC5JzS/FqK7pN+tMo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef h1:ej+64jiny5VETZTqcc1GFVAPEtaSk6U1D0kKC2MS5Yc=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/sclevine/agouti v3.0.0+incompatible h1:8IBJS6PWz3uTlMP3YBIR5f+KAldcGuOeFkFbUWfBgK4=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
@@ -53,6 +60,7 @@ github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtC
 go.opentelemetry.io/contrib/detectors/gcp v1.35.0 h1:bGvFt68+KTiAKFlacHW6AhA56GF2rS0bdD3aJYEnmzA=
 go.opentelemetry.io/contrib/detectors/gcp v1.35.0/go.mod h1:qGWP8/+ILwMRIUf9uIVLloR1uo5ZYAslM4O6OqUi1DA=
 go.opentelemetry.io/contrib/detectors/gcp v1.36.0/go.mod h1:IbBN8uAIIx734PTonTPxAxnjc2pQTxWNkwfstZ+6H2k=
+golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
@@ -71,4 +79,5 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 h1:hE3bRWtU6uceqlh4fhrSnUyjKHMKB9KrTLLG+bc0ddM=
 google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463/go.mod h1:U90ffi8eUL9MwPcrJylN5+Mk2v3vuPDptd5yyNUiRR8=
 google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a/go.mod h1:a77HrdMjoeKbnd2jmgcWdaS++ZLZAEq3orIOAEIKiVw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 h1:F29+wU6Ee6qgu9TddPgooOdaqsxTMunOoj8KA5yuS5A=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1/go.mod h1:5KF+wpkbTSbGcR9zteSqZV6fqFOWBl4Yde8En8MryZA=


### PR DESCRIPTION
## Summary
- add a new agent_swarm example that chains UTCP HTTP providers to build a swarm plan
- document the new example in the examples README
- update go.work.sum for the new module dependency resolution

## Testing
- GOWORK=off go run ./examples/agent_swarm/main.go

------
https://chatgpt.com/codex/tasks/task_e_68e656221e38832287d4b17e0bfb42d6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an agent_swarm example that coordinates multiple agents by chaining UTCP HTTP tools to produce a final swarm action plan. Updated the examples README and workspace sums.

- **New Features**
  - New example at examples/agent_swarm with a coordinator that discovers tools from a scout and analyst, chains calls, and outputs selected targets and directives.
  - README includes the new example.

- **Dependencies**
  - Example module (go.mod) with a local replace to go-utcp; go.work.sum updated.

Instructions: GOWORK=off go run ./examples/agent_swarm/main.go.

<!-- End of auto-generated description by cubic. -->

