### PR TITLE
feat: caching tool selection - codemode

### DIFF
--- a/src/plugins/codemode/cache_benchmark_test.go
+++ b/src/plugins/codemode/cache_benchmark_test.go
@@ -1,0 +1,228 @@
+package codemode
+
+import (
+	"context"
+	"testing"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+)
+
+// Benchmark tool specs without cache
+func BenchmarkToolSpecs_NoCache(b *testing.B) {
+	mock := &mockUTCP{
+		searchToolsFn: func(query string, limit int) ([]tools.Tool, error) {
+			// Simulate SearchTools returning a large list
+			result := make([]tools.Tool, 50)
+			for i := 0; i < 50; i++ {
+				result[i] = tools.Tool{
+					Name:        "test.tool" + string(rune(i)),
+					Description: "Test tool " + string(rune(i)),
+				}
+			}
+			return result, nil
+		},
+	}
+
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return "{}", nil
+		},
+	}
+
+	cm := NewCodeModeUTCP(mock, mockModel)
+	// Disable cache to benchmark without caching
+	cm.cache = nil
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cm.ToolSpecs()
+	}
+}
+
+// Benchmark tool specs with cache (first call - miss)
+func BenchmarkToolSpecs_WithCache_Miss(b *testing.B) {
+	mock := &mockUTCP{
+		searchToolsFn: func(query string, limit int) ([]tools.Tool, error) {
+			result := make([]tools.Tool, 50)
+			for i := 0; i < 50; i++ {
+				result[i] = tools.Tool{
+					Name:        "test.tool" + string(rune(i)),
+					Description: "Test tool " + string(rune(i)),
+				}
+			}
+			return result, nil
+		},
+	}
+
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return "{}", nil
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		cm := NewCodeModeUTCP(mock, mockModel)
+		b.StartTimer()
+		_ = cm.ToolSpecs()
+	}
+}
+
+// Benchmark tool specs with cache (subsequent calls - hits)
+func BenchmarkToolSpecs_WithCache_Hit(b *testing.B) {
+	mock := &mockUTCP{
+		searchToolsFn: func(query string, limit int) ([]tools.Tool, error) {
+			result := make([]tools.Tool, 50)
+			for i := 0; i < 50; i++ {
+				result[i] = tools.Tool{
+					Name:        "test.tool" + string(rune(i)),
+					Description: "Test tool " + string(rune(i)),
+				}
+			}
+			return result, nil
+		},
+	}
+
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return "{}", nil
+		},
+	}
+
+	cm := NewCodeModeUTCP(mock, mockModel)
+	// Warm up cache
+	_ = cm.ToolSpecs()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cm.ToolSpecs()
+	}
+}
+
+// Benchmark selectTools without cache
+func BenchmarkSelectTools_NoCache(b *testing.B) {
+	mock := &mockUTCP{}
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return `{"tools": ["test.tool1", "test.tool2"]}`, nil
+		},
+	}
+
+	cm := NewCodeModeUTCP(mock, mockModel)
+	// Disable cache
+	cm.cache = nil
+
+	ctx := context.Background()
+	query := "find memory tools"
+	toolsStr := "test.tool1, test.tool2, test.tool3"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = cm.selectTools(ctx, query, toolsStr)
+	}
+}
+
+// Benchmark selectTools with cache (first call - miss)
+func BenchmarkSelectTools_WithCache_Miss(b *testing.B) {
+	mock := &mockUTCP{}
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return `{"tools": ["test.tool1", "test.tool2"]}`, nil
+		},
+	}
+
+	ctx := context.Background()
+	query := "find memory tools"
+	toolsStr := "test.tool1, test.tool2, test.tool3"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		cm := NewCodeModeUTCP(mock, mockModel)
+		b.StartTimer()
+		_, _ = cm.selectTools(ctx, query, toolsStr)
+	}
+}
+
+// Benchmark selectTools with cache (subsequent calls - hits)
+func BenchmarkSelectTools_WithCache_Hit(b *testing.B) {
+	mock := &mockUTCP{}
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			return `{"tools": ["test.tool1", "test.tool2"]}`, nil
+		},
+	}
+
+	cm := NewCodeModeUTCP(mock, mockModel)
+
+	ctx := context.Background()
+	query := "find memory tools"
+	toolsStr := "test.tool1, test.tool2, test.tool3"
+
+	// Warm up cache
+	_, _ = cm.selectTools(ctx, query, toolsStr)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = cm.selectTools(ctx, query, toolsStr)
+	}
+}
+
+// Benchmark full CallTool workflow with cache
+func BenchmarkCallTool_WithCache(b *testing.B) {
+	mock := &mockUTCP{
+		searchToolsFn: func(query string, limit int) ([]tools.Tool, error) {
+			return []tools.Tool{
+				{Name: "test.tool1", Description: "Test tool 1"},
+				{Name: "test.tool2", Description: "Test tool 2"},
+			}, nil
+		},
+	}
+
+	mockModel := &mockModel{
+		GenerateFunc: func(ctx context.Context, prompt string) (any, error) {
+			// Simulate different responses for different stages
+			if stringContains(prompt, "Decide if") {
+				return `{"needs": true}`, nil
+			}
+			if stringContains(prompt, "Select ALL UTCP tools") {
+				return `{"tools": ["test.tool1"]}`, nil
+			}
+			if stringContains(prompt, "Generate a Go snippet") {
+				return `{"code": "__out = map[string]any{\"result\": \"test\"}", "stream": false}`, nil
+			}
+			return "{}", nil
+		},
+	}
+
+	cm := NewCodeModeUTCP(mock, mockModel)
+	// Mock execute to avoid actual code execution
+	cm.executeFunc = func(ctx context.Context, args CodeModeArgs) (CodeModeResult, error) {
+		return CodeModeResult{Value: "mocked result"}, nil
+	}
+
+	ctx := context.Background()
+	query := "test query"
+
+	// First call to warm up cache
+	_, _, _ = cm.CallTool(ctx, query)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = cm.CallTool(ctx, query)
+	}
+}
+
+// Helper function
+func stringContains(s, substr string) bool {
+	if len(s) < len(substr) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/src/plugins/codemode/codemode.go
+++ b/src/plugins/codemode/codemode.go
@@ -72,12 +72,18 @@ type CodeModeUTCP struct {
 	}
 	// For testing purposes, to mock the Execute method.
 	executeFunc func(ctx context.Context, args CodeModeArgs) (CodeModeResult, error)
+	// Cache for tool specs and selection results
+	cache *ToolCache
 }
 
 func NewCodeModeUTCP(client utcp.UtcpClientInterface, model interface {
 	Generate(ctx context.Context, prompt string) (any, error)
 }) *CodeModeUTCP {
-	return &CodeModeUTCP{client: client, model: model}
+	return &CodeModeUTCP{
+		client: client,
+		model:  model,
+		cache:  NewToolCache(),
+	}
 }
 
 //

--- a/src/plugins/codemode/tool_cache.go
+++ b/src/plugins/codemode/tool_cache.go
@@ -1,0 +1,281 @@
+package codemode
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+)
+
+// ToolCache provides thread-safe caching for tool specs and selection results
+type ToolCache struct {
+	// Tool specs cache
+	toolSpecsMu    sync.RWMutex
+	toolSpecsCache []tools.Tool
+	toolSpecsTime  time.Time
+	toolSpecsTTL   time.Duration
+
+	// Tool selection cache (query -> selected tools)
+	selectionMu    sync.RWMutex
+	selectionCache map[string]*selectionCacheEntry
+	selectionTTL   time.Duration
+
+	// Stats for monitoring
+	statsMu         sync.RWMutex
+	specsHits       int64
+	specsMisses     int64
+	selectionHits   int64
+	selectionMisses int64
+}
+
+type selectionCacheEntry struct {
+	tools     []string
+	timestamp time.Time
+}
+
+// NewToolCache creates a new tool cache with configurable TTLs
+func NewToolCache() *ToolCache {
+	// Default: cache tool specs for 5 minutes
+	specsTTL := parseDurationFromEnv("UTCP_TOOL_SPECS_CACHE_TTL", 5*time.Minute)
+
+	// Default: cache tool selections for 2 minutes
+	selectionTTL := parseDurationFromEnv("UTCP_TOOL_SELECTION_CACHE_TTL", 2*time.Minute)
+
+	return &ToolCache{
+		toolSpecsTTL:   specsTTL,
+		selectionTTL:   selectionTTL,
+		selectionCache: make(map[string]*selectionCacheEntry),
+	}
+}
+
+// GetToolSpecs retrieves cached tool specs or returns nil if expired/missing
+func (tc *ToolCache) GetToolSpecs() []tools.Tool {
+	tc.toolSpecsMu.RLock()
+	defer tc.toolSpecsMu.RUnlock()
+
+	if time.Since(tc.toolSpecsTime) > tc.toolSpecsTTL {
+		tc.statsMu.Lock()
+		tc.specsMisses++
+		tc.statsMu.Unlock()
+		return nil
+	}
+
+	if tc.toolSpecsCache == nil {
+		tc.statsMu.Lock()
+		tc.specsMisses++
+		tc.statsMu.Unlock()
+		return nil
+	}
+
+	tc.statsMu.Lock()
+	tc.specsHits++
+	tc.statsMu.Unlock()
+
+	// Return a copy to prevent external modifications
+	result := make([]tools.Tool, len(tc.toolSpecsCache))
+	copy(result, tc.toolSpecsCache)
+	return result
+}
+
+// SetToolSpecs stores tool specs in cache
+func (tc *ToolCache) SetToolSpecs(specs []tools.Tool) {
+	tc.toolSpecsMu.Lock()
+	defer tc.toolSpecsMu.Unlock()
+
+	// Store a copy to prevent external modifications
+	tc.toolSpecsCache = make([]tools.Tool, len(specs))
+	copy(tc.toolSpecsCache, specs)
+	tc.toolSpecsTime = time.Now()
+}
+
+// GetSelectedTools retrieves cached tool selection for a query
+func (tc *ToolCache) GetSelectedTools(query string, availableTools string) []string {
+	key := tc.cacheKey(query, availableTools)
+
+	tc.selectionMu.RLock()
+	entry, exists := tc.selectionCache[key]
+	tc.selectionMu.RUnlock()
+
+	if !exists {
+		tc.statsMu.Lock()
+		tc.selectionMisses++
+		tc.statsMu.Unlock()
+		return nil
+	}
+
+	if time.Since(entry.timestamp) > tc.selectionTTL {
+		// Expired - clean up in background
+		go tc.removeExpiredSelection(key)
+		tc.statsMu.Lock()
+		tc.selectionMisses++
+		tc.statsMu.Unlock()
+		return nil
+	}
+
+	tc.statsMu.Lock()
+	tc.selectionHits++
+	tc.statsMu.Unlock()
+
+	// Return a copy to prevent external modifications
+	result := make([]string, len(entry.tools))
+	copy(result, entry.tools)
+	return result
+}
+
+// SetSelectedTools stores tool selection result in cache
+func (tc *ToolCache) SetSelectedTools(query string, availableTools string, selectedTools []string) {
+	key := tc.cacheKey(query, availableTools)
+
+	tc.selectionMu.Lock()
+	defer tc.selectionMu.Unlock()
+
+	// Store a copy to prevent external modifications
+	toolsCopy := make([]string, len(selectedTools))
+	copy(toolsCopy, selectedTools)
+
+	tc.selectionCache[key] = &selectionCacheEntry{
+		tools:     toolsCopy,
+		timestamp: time.Now(),
+	}
+}
+
+// InvalidateToolSpecs clears the tool specs cache
+func (tc *ToolCache) InvalidateToolSpecs() {
+	tc.toolSpecsMu.Lock()
+	defer tc.toolSpecsMu.Unlock()
+
+	tc.toolSpecsCache = nil
+	tc.toolSpecsTime = time.Time{}
+}
+
+// InvalidateSelections clears all tool selection cache entries
+func (tc *ToolCache) InvalidateSelections() {
+	tc.selectionMu.Lock()
+	defer tc.selectionMu.Unlock()
+
+	tc.selectionCache = make(map[string]*selectionCacheEntry)
+}
+
+// InvalidateAll clears all caches
+func (tc *ToolCache) InvalidateAll() {
+	tc.InvalidateToolSpecs()
+	tc.InvalidateSelections()
+}
+
+// CleanExpired removes expired entries from selection cache
+func (tc *ToolCache) CleanExpired() {
+	tc.selectionMu.Lock()
+	defer tc.selectionMu.Unlock()
+
+	now := time.Now()
+	for key, entry := range tc.selectionCache {
+		if now.Sub(entry.timestamp) > tc.selectionTTL {
+			delete(tc.selectionCache, key)
+		}
+	}
+}
+
+// Stats returns cache performance statistics
+func (tc *ToolCache) Stats() CacheStats {
+	tc.statsMu.RLock()
+	defer tc.statsMu.RUnlock()
+
+	return CacheStats{
+		SpecsHits:       tc.specsHits,
+		SpecsMisses:     tc.specsMisses,
+		SelectionHits:   tc.selectionHits,
+		SelectionMisses: tc.selectionMisses,
+		SelectionSize:   tc.getSelectionCacheSize(),
+	}
+}
+
+// CacheStats holds cache performance metrics
+type CacheStats struct {
+	SpecsHits       int64
+	SpecsMisses     int64
+	SelectionHits   int64
+	SelectionMisses int64
+	SelectionSize   int
+}
+
+// HitRate returns the cache hit rate for tool specs
+func (cs CacheStats) SpecsHitRate() float64 {
+	total := cs.SpecsHits + cs.SpecsMisses
+	if total == 0 {
+		return 0.0
+	}
+	return float64(cs.SpecsHits) / float64(total)
+}
+
+// SelectionHitRate returns the cache hit rate for tool selections
+func (cs CacheStats) SelectionHitRate() float64 {
+	total := cs.SelectionHits + cs.SelectionMisses
+	if total == 0 {
+		return 0.0
+	}
+	return float64(cs.SelectionHits) / float64(total)
+}
+
+// cacheKey creates a hash-based cache key from query and available tools
+func (tc *ToolCache) cacheKey(query string, availableTools string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(query))
+	hasher.Write([]byte("\n---\n"))
+	hasher.Write([]byte(availableTools))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// removeExpiredSelection removes a specific cache entry
+func (tc *ToolCache) removeExpiredSelection(key string) {
+	tc.selectionMu.Lock()
+	defer tc.selectionMu.Unlock()
+	delete(tc.selectionCache, key)
+}
+
+// getSelectionCacheSize returns the current size of selection cache
+func (tc *ToolCache) getSelectionCacheSize() int {
+	tc.selectionMu.RLock()
+	defer tc.selectionMu.RUnlock()
+	return len(tc.selectionCache)
+}
+
+// StartCleanupRoutine starts a background goroutine to periodically clean expired entries
+func (tc *ToolCache) StartCleanupRoutine(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				tc.CleanExpired()
+			}
+		}
+	}()
+}
+
+// parseDurationFromEnv parses a duration from environment variable or returns default
+func parseDurationFromEnv(envVar string, defaultDuration time.Duration) time.Duration {
+	val := os.Getenv(envVar)
+	if val == "" {
+		return defaultDuration
+	}
+
+	// Try parsing as duration string (e.g., "5m", "10s")
+	if d, err := time.ParseDuration(val); err == nil {
+		return d
+	}
+
+	// Try parsing as seconds
+	if seconds, err := strconv.Atoi(val); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+
+	return defaultDuration
+}

--- a/src/plugins/codemode/tool_cache_test.go
+++ b/src/plugins/codemode/tool_cache_test.go
@@ -1,0 +1,442 @@
+package codemode
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+)
+
+func TestToolCache_ToolSpecs(t *testing.T) {
+	cache := NewToolCache()
+
+	// Test cache miss
+	specs := cache.GetToolSpecs()
+	if specs != nil {
+		t.Error("Expected nil for empty cache")
+	}
+
+	// Set tool specs
+	testSpecs := []tools.Tool{
+		{Name: "test.tool1", Description: "Test tool 1"},
+		{Name: "test.tool2", Description: "Test tool 2"},
+	}
+	cache.SetToolSpecs(testSpecs)
+
+	// Test cache hit
+	cached := cache.GetToolSpecs()
+	if cached == nil {
+		t.Fatal("Expected cached specs, got nil")
+	}
+	if len(cached) != 2 {
+		t.Errorf("Expected 2 tools, got %d", len(cached))
+	}
+
+	// Verify copy semantics - modifying returned value shouldn't affect cache
+	cached[0].Name = "modified"
+	cached2 := cache.GetToolSpecs()
+	if cached2[0].Name == "modified" {
+		t.Error("Cache returned same slice instead of copy")
+	}
+}
+
+func TestToolCache_ToolSpecs_Expiration(t *testing.T) {
+	// Set very short TTL
+	os.Setenv("UTCP_TOOL_SPECS_CACHE_TTL", "100ms")
+	defer os.Unsetenv("UTCP_TOOL_SPECS_CACHE_TTL")
+
+	cache := NewToolCache()
+
+	testSpecs := []tools.Tool{
+		{Name: "test.tool1", Description: "Test tool 1"},
+	}
+	cache.SetToolSpecs(testSpecs)
+
+	// Should be cached immediately
+	if cache.GetToolSpecs() == nil {
+		t.Error("Expected cached value immediately after set")
+	}
+
+	// Wait for expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be expired
+	if cache.GetToolSpecs() != nil {
+		t.Error("Expected nil after TTL expiration")
+	}
+}
+
+func TestToolCache_SelectedTools(t *testing.T) {
+	cache := NewToolCache()
+
+	query := "find memory tools"
+	availableTools := "tool1, tool2, tool3"
+
+	// Test cache miss
+	selected := cache.GetSelectedTools(query, availableTools)
+	if selected != nil {
+		t.Error("Expected nil for empty cache")
+	}
+
+	// Set selection
+	testSelection := []string{"tool1", "tool3"}
+	cache.SetSelectedTools(query, availableTools, testSelection)
+
+	// Test cache hit
+	cached := cache.GetSelectedTools(query, availableTools)
+	if cached == nil {
+		t.Fatal("Expected cached selection, got nil")
+	}
+	if len(cached) != 2 {
+		t.Errorf("Expected 2 tools, got %d", len(cached))
+	}
+
+	// Verify copy semantics
+	cached[0] = "modified"
+	cached2 := cache.GetSelectedTools(query, availableTools)
+	if cached2[0] == "modified" {
+		t.Error("Cache returned same slice instead of copy")
+	}
+}
+
+func TestToolCache_SelectedTools_DifferentQueries(t *testing.T) {
+	cache := NewToolCache()
+
+	availableTools := "tool1, tool2, tool3"
+
+	// Cache different selections for different queries
+	cache.SetSelectedTools("query1", availableTools, []string{"tool1"})
+	cache.SetSelectedTools("query2", availableTools, []string{"tool2"})
+
+	// Verify separation
+	sel1 := cache.GetSelectedTools("query1", availableTools)
+	sel2 := cache.GetSelectedTools("query2", availableTools)
+
+	if len(sel1) != 1 || sel1[0] != "tool1" {
+		t.Error("Query1 returned wrong selection")
+	}
+	if len(sel2) != 1 || sel2[0] != "tool2" {
+		t.Error("Query2 returned wrong selection")
+	}
+}
+
+func TestToolCache_SelectedTools_DifferentAvailableTools(t *testing.T) {
+	cache := NewToolCache()
+
+	query := "find tools"
+
+	// Cache selections with different available tools
+	cache.SetSelectedTools(query, "tool1, tool2", []string{"tool1"})
+	cache.SetSelectedTools(query, "tool3, tool4", []string{"tool3"})
+
+	// Verify separation based on available tools
+	sel1 := cache.GetSelectedTools(query, "tool1, tool2")
+	sel2 := cache.GetSelectedTools(query, "tool3, tool4")
+
+	if len(sel1) != 1 || sel1[0] != "tool1" {
+		t.Error("First available tools set returned wrong selection")
+	}
+	if len(sel2) != 1 || sel2[0] != "tool3" {
+		t.Error("Second available tools set returned wrong selection")
+	}
+}
+
+func TestToolCache_SelectedTools_Expiration(t *testing.T) {
+	// Set very short TTL
+	os.Setenv("UTCP_TOOL_SELECTION_CACHE_TTL", "100ms")
+	defer os.Unsetenv("UTCP_TOOL_SELECTION_CACHE_TTL")
+
+	cache := NewToolCache()
+
+	query := "find tools"
+	availableTools := "tool1, tool2"
+	cache.SetSelectedTools(query, availableTools, []string{"tool1"})
+
+	// Should be cached immediately
+	if cache.GetSelectedTools(query, availableTools) == nil {
+		t.Error("Expected cached value immediately after set")
+	}
+
+	// Wait for expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be expired
+	if cache.GetSelectedTools(query, availableTools) != nil {
+		t.Error("Expected nil after TTL expiration")
+	}
+}
+
+func TestToolCache_Invalidation(t *testing.T) {
+	cache := NewToolCache()
+
+	// Set up cache
+	testSpecs := []tools.Tool{{Name: "test.tool1"}}
+	cache.SetToolSpecs(testSpecs)
+	cache.SetSelectedTools("query", "tools", []string{"tool1"})
+
+	// Test InvalidateToolSpecs
+	cache.InvalidateToolSpecs()
+	if cache.GetToolSpecs() != nil {
+		t.Error("Tool specs should be invalidated")
+	}
+
+	// Set up again
+	cache.SetToolSpecs(testSpecs)
+	cache.SetSelectedTools("query", "tools", []string{"tool1"})
+
+	// Test InvalidateSelections
+	cache.InvalidateSelections()
+	if cache.GetSelectedTools("query", "tools") != nil {
+		t.Error("Selections should be invalidated")
+	}
+	if cache.GetToolSpecs() == nil {
+		t.Error("Tool specs should still be cached")
+	}
+
+	// Test InvalidateAll
+	cache.SetSelectedTools("query", "tools", []string{"tool1"})
+	cache.InvalidateAll()
+	if cache.GetToolSpecs() != nil {
+		t.Error("Tool specs should be invalidated")
+	}
+	if cache.GetSelectedTools("query", "tools") != nil {
+		t.Error("Selections should be invalidated")
+	}
+}
+
+func TestToolCache_Stats(t *testing.T) {
+	cache := NewToolCache()
+
+	// Initial stats should be zero
+	stats := cache.Stats()
+	if stats.SpecsHits != 0 || stats.SpecsMisses != 0 {
+		t.Error("Initial stats should be zero")
+	}
+
+	// Cache miss
+	cache.GetToolSpecs()
+	stats = cache.Stats()
+	if stats.SpecsMisses != 1 {
+		t.Errorf("Expected 1 miss, got %d", stats.SpecsMisses)
+	}
+
+	// Cache hit
+	cache.SetToolSpecs([]tools.Tool{{Name: "test"}})
+	cache.GetToolSpecs()
+	cache.GetToolSpecs()
+	stats = cache.Stats()
+	if stats.SpecsHits != 2 {
+		t.Errorf("Expected 2 hits, got %d", stats.SpecsHits)
+	}
+	if stats.SpecsMisses != 1 {
+		t.Errorf("Expected 1 miss, got %d", stats.SpecsMisses)
+	}
+
+	// Test hit rate
+	hitRate := stats.SpecsHitRate()
+	expectedRate := 2.0 / 3.0
+	if hitRate < expectedRate-0.01 || hitRate > expectedRate+0.01 {
+		t.Errorf("Expected hit rate ~%.2f, got %.2f", expectedRate, hitRate)
+	}
+}
+
+func TestToolCache_SelectionStats(t *testing.T) {
+	cache := NewToolCache()
+
+	query := "test query"
+	tools := "tool1, tool2"
+
+	// Miss
+	cache.GetSelectedTools(query, tools)
+	stats := cache.Stats()
+	if stats.SelectionMisses != 1 {
+		t.Errorf("Expected 1 miss, got %d", stats.SelectionMisses)
+	}
+
+	// Hits
+	cache.SetSelectedTools(query, tools, []string{"tool1"})
+	cache.GetSelectedTools(query, tools)
+	cache.GetSelectedTools(query, tools)
+
+	stats = cache.Stats()
+	if stats.SelectionHits != 2 {
+		t.Errorf("Expected 2 hits, got %d", stats.SelectionHits)
+	}
+
+	hitRate := stats.SelectionHitRate()
+	expectedRate := 2.0 / 3.0
+	if hitRate < expectedRate-0.01 || hitRate > expectedRate+0.01 {
+		t.Errorf("Expected hit rate ~%.2f, got %.2f", expectedRate, hitRate)
+	}
+}
+
+func TestToolCache_CleanExpired(t *testing.T) {
+	// Set very short TTL
+	os.Setenv("UTCP_TOOL_SELECTION_CACHE_TTL", "50ms")
+	defer os.Unsetenv("UTCP_TOOL_SELECTION_CACHE_TTL")
+
+	cache := NewToolCache()
+
+	// Add multiple entries
+	for i := 0; i < 5; i++ {
+		cache.SetSelectedTools("query"+string(rune(i)), "tools", []string{"tool1"})
+	}
+
+	stats := cache.Stats()
+	if stats.SelectionSize != 5 {
+		t.Errorf("Expected 5 entries, got %d", stats.SelectionSize)
+	}
+
+	// Wait for expiration
+	time.Sleep(100 * time.Millisecond)
+
+	// Clean expired
+	cache.CleanExpired()
+
+	stats = cache.Stats()
+	if stats.SelectionSize != 0 {
+		t.Errorf("Expected 0 entries after cleanup, got %d", stats.SelectionSize)
+	}
+}
+
+func TestToolCache_CleanupRoutine(t *testing.T) {
+	// Set very short TTL
+	os.Setenv("UTCP_TOOL_SELECTION_CACHE_TTL", "50ms")
+	defer os.Unsetenv("UTCP_TOOL_SELECTION_CACHE_TTL")
+
+	cache := NewToolCache()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start cleanup routine with short interval
+	cache.StartCleanupRoutine(ctx, 75*time.Millisecond)
+
+	// Add entries
+	for i := 0; i < 3; i++ {
+		cache.SetSelectedTools("query"+string(rune(i)), "tools", []string{"tool1"})
+	}
+
+	// Wait for cleanup to run
+	time.Sleep(200 * time.Millisecond)
+
+	stats := cache.Stats()
+	if stats.SelectionSize != 0 {
+		t.Errorf("Expected 0 entries after automatic cleanup, got %d", stats.SelectionSize)
+	}
+
+	// Cancel context and ensure routine stops
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestToolCache_ConcurrentAccess(t *testing.T) {
+	cache := NewToolCache()
+	done := make(chan bool)
+
+	// Concurrent writes
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			cache.SetToolSpecs([]tools.Tool{{Name: "tool" + string(rune(n))}})
+			done <- true
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < 10; i++ {
+		go func() {
+			_ = cache.GetToolSpecs()
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	// If we get here without deadlock, test passes
+}
+
+func TestParseDurationFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		defaultDur  time.Duration
+		expectedDur time.Duration
+	}{
+		{"empty", "", 5 * time.Minute, 5 * time.Minute},
+		{"duration string", "10s", 5 * time.Minute, 10 * time.Second},
+		{"minutes", "2m", 5 * time.Minute, 2 * time.Minute},
+		{"hours", "1h", 5 * time.Minute, 1 * time.Hour},
+		{"seconds as int", "30", 5 * time.Minute, 30 * time.Second},
+		{"invalid", "invalid", 5 * time.Minute, 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVar := "TEST_DURATION_VAR"
+			if tt.envValue != "" {
+				os.Setenv(envVar, tt.envValue)
+				defer os.Unsetenv(envVar)
+			}
+
+			result := parseDurationFromEnv(envVar, tt.defaultDur)
+			if result != tt.expectedDur {
+				t.Errorf("Expected %v, got %v", tt.expectedDur, result)
+			}
+		})
+	}
+}
+
+func BenchmarkToolCache_GetToolSpecs(b *testing.B) {
+	cache := NewToolCache()
+	testSpecs := make([]tools.Tool, 50)
+	for i := 0; i < 50; i++ {
+		testSpecs[i] = tools.Tool{Name: "tool" + string(rune(i))}
+	}
+	cache.SetToolSpecs(testSpecs)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.GetToolSpecs()
+	}
+}
+
+func BenchmarkToolCache_SetToolSpecs(b *testing.B) {
+	cache := NewToolCache()
+	testSpecs := make([]tools.Tool, 50)
+	for i := 0; i < 50; i++ {
+		testSpecs[i] = tools.Tool{Name: "tool" + string(rune(i))}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.SetToolSpecs(testSpecs)
+	}
+}
+
+func BenchmarkToolCache_GetSelectedTools(b *testing.B) {
+	cache := NewToolCache()
+	query := "find memory tools"
+	tools := "tool1, tool2, tool3, tool4, tool5"
+	cache.SetSelectedTools(query, tools, []string{"tool1", "tool3"})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.GetSelectedTools(query, tools)
+	}
+}
+
+func BenchmarkToolCache_SetSelectedTools(b *testing.B) {
+	cache := NewToolCache()
+	query := "find memory tools"
+	tools := "tool1, tool2, tool3, tool4, tool5"
+	selection := []string{"tool1", "tool3"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.SetSelectedTools(query, tools, selection)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds caching for UTCP tool specs and tool selection in CodeMode to cut repeated model prompts and UTCP lookups. This improves CallTool performance and reduces load.

- **New Features**
  - Cache tool specs and selections with TTLs (defaults: 5m and 2m), configurable via UTCP_TOOL_SPECS_CACHE_TTL and UTCP_TOOL_SELECTION_CACHE_TTL.
  - Integrated cache checks in ToolSpecs and selectTools to reduce duplicate work; cache fills on miss.
  - Cache management APIs: InvalidateToolSpecsCache, InvalidateSelectionsCache, InvalidateAllCaches, CacheStats, and StartCacheCleanup(ctx, interval).
  - Added comprehensive tests and benchmarks, including end-to-end CallTool flow.

<sup>Written for commit 7283d9b87ecce3b8795dfc5a3de807ecef88767f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

