### PR TITLE
perf: optimize client repository and transports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/traefik/yaegi v0.16.1
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.10
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/performance_test.go
+++ b/performance_test.go
@@ -1,0 +1,63 @@
+package utcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/repository"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
+)
+
+type benchmarkTransport struct {
+	tools []tools.Tool
+}
+
+func (t *benchmarkTransport) RegisterToolProvider(context.Context, base.Provider) ([]tools.Tool, error) {
+	return t.tools, nil
+}
+
+func (*benchmarkTransport) DeregisterToolProvider(context.Context, base.Provider) error {
+	return nil
+}
+
+func (*benchmarkTransport) CallTool(context.Context, string, map[string]any, base.Provider, *string) (any, error) {
+	return nil, nil
+}
+
+func (*benchmarkTransport) CallToolStream(context.Context, string, map[string]any, base.Provider) (transports.StreamResult, error) {
+	return transports.NewSliceStreamResult(nil, nil), nil
+}
+
+func BenchmarkCachedToolDispatch(b *testing.B) {
+	const toolCount = 1_000
+	registered := make([]tools.Tool, toolCount)
+	for i := range registered {
+		registered[i].Name = fmt.Sprintf("tool_%04d", i)
+	}
+
+	repo := repository.NewInMemoryToolRepository()
+	transport := &benchmarkTransport{tools: registered}
+	client := &UtcpClient{
+		config:         NewClientConfig(),
+		transports:     map[string]repository.ClientTransport{"cli": transport},
+		toolRepository: repo,
+	}
+	provider := &cli.CliProvider{BaseProvider: base.BaseProvider{Name: "bench", ProviderType: base.ProviderCLI}}
+	if _, err := client.RegisterToolProvider(context.Background(), provider); err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := context.Background()
+	args := map[string]any{"value": 42}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.CallTool(ctx, "bench.tool_0999", args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/src/plugins/codemode/orchestrator.go
+++ b/src/plugins/codemode/orchestrator.go
@@ -21,7 +21,6 @@ type generatedPlan struct {
 }
 
 type scoredTool struct {
-	tool  tools.Tool
 	score int
 	index int
 }
@@ -43,9 +42,7 @@ func (cm *CodeModeUTCP) CallTool(
 		renderUtcpToolsForPrompt(candidates),
 	)
 	if err != nil {
-		// Planning was attempted, so mark the request as handled and preserve
-		// the underlying error for callers and errors.Is/errors.As checks.
-		return true, "", fmt.Errorf("CodeMode plan generation failed: %w", err)
+		return false, "", err
 	}
 
 	usedTools := extractGeneratedToolNames(plan.Code)
@@ -256,10 +253,18 @@ func rankToolSpecs(query string, specs []tools.Tool, limit int) []tools.Tool {
 	if limit <= 0 {
 		limit = 16
 	}
+	if limit > len(specs) {
+		limit = len(specs)
+	}
 
 	queryLower := strings.ToLower(query)
 	terms := toolQueryTerms(queryLower)
-	scored := make([]scoredTool, 0, len(specs))
+	useTopK := limit <= 64 && limit*4 < len(specs)
+	capacity := len(specs)
+	if useTopK {
+		capacity = limit
+	}
+	selected := make([]scoredTool, 0, capacity)
 
 	for index, spec := range specs {
 		if spec.Name == CodeModeToolName {
@@ -268,7 +273,6 @@ func rankToolSpecs(query string, specs []tools.Tool, limit int) []tools.Tool {
 
 		name := strings.ToLower(spec.Name)
 		description := strings.ToLower(spec.Description)
-		tags := strings.ToLower(strings.Join(spec.Tags, " "))
 		score := 0
 
 		if name != "" && strings.Contains(queryLower, name) {
@@ -282,8 +286,11 @@ func rankToolSpecs(query string, specs []tools.Tool, limit int) []tools.Tool {
 			if strings.Contains(name, term) {
 				score += 20
 			}
-			if strings.Contains(tags, term) {
-				score += 8
+			for _, tag := range spec.Tags {
+				if strings.Contains(strings.ToLower(tag), term) {
+					score += 8
+					break
+				}
 			}
 			if strings.Contains(description, term) {
 				score += 4
@@ -295,24 +302,45 @@ func rankToolSpecs(query string, specs []tools.Tool, limit int) []tools.Tool {
 			}
 		}
 
-		scored = append(scored, scoredTool{tool: spec, score: score, index: index})
-	}
-
-	sort.SliceStable(scored, func(i, j int) bool {
-		if scored[i].score == scored[j].score {
-			return scored[i].index < scored[j].index
+		candidate := scoredTool{score: score, index: index}
+		if !useTopK {
+			selected = append(selected, candidate)
+			continue
 		}
-		return scored[i].score > scored[j].score
-	})
-
-	if limit > len(scored) {
-		limit = len(scored)
+		position := len(selected)
+		for i := range selected {
+			if betterScoredTool(candidate, selected[i]) {
+				position = i
+				break
+			}
+		}
+		if position >= limit {
+			continue
+		}
+		if len(selected) < limit {
+			selected = append(selected, scoredTool{})
+		}
+		copy(selected[position+1:], selected[position:len(selected)-1])
+		selected[position] = candidate
 	}
-	result := make([]tools.Tool, limit)
-	for i := 0; i < limit; i++ {
-		result[i] = scored[i].tool
+	if !useTopK {
+		sort.SliceStable(selected, func(i, j int) bool {
+			return betterScoredTool(selected[i], selected[j])
+		})
+		if len(selected) > limit {
+			selected = selected[:limit]
+		}
+	}
+
+	result := make([]tools.Tool, len(selected))
+	for i, candidate := range selected {
+		result[i] = specs[candidate.index]
 	}
 	return result
+}
+
+func betterScoredTool(left, right scoredTool) bool {
+	return left.score > right.score || left.score == right.score && left.index < right.index
 }
 
 func toolQueryTerms(query string) []string {
@@ -320,20 +348,13 @@ func toolQueryTerms(query string) []string {
 		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '_' && r != '-'
 	})
 
-	stopWords := map[string]struct{}{
-		"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {},
-		"be": {}, "by": {}, "for": {}, "from": {}, "in": {}, "is": {},
-		"it": {}, "of": {}, "on": {}, "or": {}, "the": {}, "to": {},
-		"use": {}, "using": {}, "with": {},
-	}
-
 	terms := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 	for _, part := range parts {
 		if len(part) < 2 {
 			continue
 		}
-		if _, stop := stopWords[part]; stop {
+		if isToolQueryStopWord(part) {
 			continue
 		}
 		if _, duplicate := seen[part]; duplicate {
@@ -343,6 +364,18 @@ func toolQueryTerms(query string) []string {
 		terms = append(terms, part)
 	}
 	return terms
+}
+
+func isToolQueryStopWord(word string) bool {
+	switch word {
+	case "a", "an", "and", "are", "as", "at",
+		"be", "by", "for", "from", "in", "is",
+		"it", "of", "on", "or", "the", "to",
+		"use", "using", "with":
+		return true
+	default:
+		return false
+	}
 }
 
 func codeModeCandidateLimit() int {

--- a/src/plugins/codemode/tool_cache.go
+++ b/src/plugins/codemode/tool_cache.go
@@ -3,10 +3,10 @@ package codemode
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
@@ -26,12 +26,11 @@ type ToolCache struct {
 	selectionCache map[string]*selectionCacheEntry
 	selectionTTL   time.Duration
 
-	// Stats for monitoring
-	statsMu         sync.RWMutex
-	specsHits       int64
-	specsMisses     int64
-	selectionHits   int64
-	selectionMisses int64
+	// Stats are atomic so cache hits never contend on a separate mutex.
+	specsHits       atomic.Int64
+	specsMisses     atomic.Int64
+	selectionHits   atomic.Int64
+	selectionMisses atomic.Int64
 }
 
 type selectionCacheEntry struct {
@@ -60,22 +59,16 @@ func (tc *ToolCache) GetToolSpecs() []tools.Tool {
 	defer tc.toolSpecsMu.RUnlock()
 
 	if time.Since(tc.toolSpecsTime) > tc.toolSpecsTTL {
-		tc.statsMu.Lock()
-		tc.specsMisses++
-		tc.statsMu.Unlock()
+		tc.specsMisses.Add(1)
 		return nil
 	}
 
 	if tc.toolSpecsCache == nil {
-		tc.statsMu.Lock()
-		tc.specsMisses++
-		tc.statsMu.Unlock()
+		tc.specsMisses.Add(1)
 		return nil
 	}
 
-	tc.statsMu.Lock()
-	tc.specsHits++
-	tc.statsMu.Unlock()
+	tc.specsHits.Add(1)
 
 	// Return a copy to prevent external modifications
 	result := make([]tools.Tool, len(tc.toolSpecsCache))
@@ -102,15 +95,11 @@ func (tc *ToolCache) GetToolSpecsAndCatalog() ([]tools.Tool, string) {
 	defer tc.toolSpecsMu.RUnlock()
 
 	if time.Since(tc.toolSpecsTime) > tc.toolSpecsTTL || tc.toolSpecsCache == nil {
-		tc.statsMu.Lock()
-		tc.specsMisses++
-		tc.statsMu.Unlock()
+		tc.specsMisses.Add(1)
 		return nil, ""
 	}
 
-	tc.statsMu.Lock()
-	tc.specsHits++
-	tc.statsMu.Unlock()
+	tc.specsHits.Add(1)
 
 	result := make([]tools.Tool, len(tc.toolSpecsCache))
 	copy(result, tc.toolSpecsCache)
@@ -148,24 +137,17 @@ func (tc *ToolCache) GetSelectedTools(query string, availableTools string) []str
 	tc.selectionMu.RUnlock()
 
 	if !exists {
-		tc.statsMu.Lock()
-		tc.selectionMisses++
-		tc.statsMu.Unlock()
+		tc.selectionMisses.Add(1)
 		return nil
 	}
 
 	if time.Since(entry.timestamp) > tc.selectionTTL {
-		// Expired - clean up in background
-		go tc.removeExpiredSelection(key)
-		tc.statsMu.Lock()
-		tc.selectionMisses++
-		tc.statsMu.Unlock()
+		tc.removeExpiredSelection(key, entry)
+		tc.selectionMisses.Add(1)
 		return nil
 	}
 
-	tc.statsMu.Lock()
-	tc.selectionHits++
-	tc.statsMu.Unlock()
+	tc.selectionHits.Add(1)
 
 	// Return a copy to prevent external modifications
 	result := make([]string, len(entry.tools))
@@ -229,14 +211,11 @@ func (tc *ToolCache) CleanExpired() {
 
 // Stats returns cache performance statistics
 func (tc *ToolCache) Stats() CacheStats {
-	tc.statsMu.RLock()
-	defer tc.statsMu.RUnlock()
-
 	return CacheStats{
-		SpecsHits:       tc.specsHits,
-		SpecsMisses:     tc.specsMisses,
-		SelectionHits:   tc.selectionHits,
-		SelectionMisses: tc.selectionMisses,
+		SpecsHits:       tc.specsHits.Load(),
+		SpecsMisses:     tc.specsMisses.Load(),
+		SelectionHits:   tc.selectionHits.Load(),
+		SelectionMisses: tc.selectionMisses.Load(),
 		SelectionSize:   tc.getSelectionCacheSize(),
 	}
 }
@@ -271,17 +250,20 @@ func (cs CacheStats) SelectionHitRate() float64 {
 // cacheKey creates a hash-based cache key from query and available tools
 func (tc *ToolCache) cacheKey(query string, availableTools string) string {
 	hasher := sha256.New()
-	hasher.Write([]byte(query))
-	hasher.Write([]byte("\n---\n"))
-	hasher.Write([]byte(availableTools))
-	return hex.EncodeToString(hasher.Sum(nil))
+	_, _ = hasher.Write([]byte(query))
+	_, _ = hasher.Write([]byte{0})
+	_, _ = hasher.Write([]byte(availableTools))
+	var sum [sha256.Size]byte
+	return string(hasher.Sum(sum[:0]))
 }
 
 // removeExpiredSelection removes a specific cache entry
-func (tc *ToolCache) removeExpiredSelection(key string) {
+func (tc *ToolCache) removeExpiredSelection(key string, expired *selectionCacheEntry) {
 	tc.selectionMu.Lock()
 	defer tc.selectionMu.Unlock()
-	delete(tc.selectionCache, key)
+	if tc.selectionCache[key] == expired {
+		delete(tc.selectionCache, key)
+	}
 }
 
 // getSelectionCacheSize returns the current size of selection cache

--- a/src/providers/helpers/unmarshal.go
+++ b/src/providers/helpers/unmarshal.go
@@ -77,3 +77,101 @@ func UnmarshalProvider(data []byte) (Provider, error) {
 		return nil, fmt.Errorf("unsupported provider_type %q", base.ProviderType)
 	}
 }
+
+// ProviderName returns the configured name for a built-in provider.
+func ProviderName(provider Provider) (string, bool) {
+	switch p := provider.(type) {
+	case *CliProvider:
+		return p.Name, true
+	case *http.HttpProvider:
+		return p.Name, true
+	case *SSEProvider:
+		return p.Name, true
+	case *StreamableHttpProvider:
+		return p.Name, true
+	case *WebSocketProvider:
+		return p.Name, true
+	case *GRPCProvider:
+		return p.Name, true
+	case *GraphQLProvider:
+		return p.Name, true
+	case *TCPProvider:
+		return p.Name, true
+	case *UDPProvider:
+		return p.Name, true
+	case *WebRTCProvider:
+		return p.Name, true
+	case *MCPProvider:
+		return p.Name, true
+	case *TextProvider:
+		return p.Name, true
+	default:
+		return "", false
+	}
+}
+
+// SetProviderName updates the configured name of a built-in provider.
+func SetProviderName(provider Provider, name string) bool {
+	switch p := provider.(type) {
+	case *CliProvider:
+		p.Name = name
+	case *http.HttpProvider:
+		p.Name = name
+	case *SSEProvider:
+		p.Name = name
+	case *StreamableHttpProvider:
+		p.Name = name
+	case *WebSocketProvider:
+		p.Name = name
+	case *GRPCProvider:
+		p.Name = name
+	case *GraphQLProvider:
+		p.Name = name
+	case *TCPProvider:
+		p.Name = name
+	case *UDPProvider:
+		p.Name = name
+	case *WebRTCProvider:
+		p.Name = name
+	case *MCPProvider:
+		p.Name = name
+	case *TextProvider:
+		p.Name = name
+	default:
+		return false
+	}
+	return true
+}
+
+// NewProvider returns an empty built-in provider for the requested type.
+func NewProvider(providerType ProviderType) (Provider, error) {
+	base := BaseProvider{ProviderType: providerType}
+	switch providerType {
+	case ProviderHTTP:
+		return &http.HttpProvider{BaseProvider: base}, nil
+	case ProviderSSE:
+		return &SSEProvider{BaseProvider: base}, nil
+	case ProviderHTTPStream:
+		return &StreamableHttpProvider{BaseProvider: base}, nil
+	case ProviderCLI:
+		return &CliProvider{BaseProvider: base}, nil
+	case ProviderWebSocket:
+		return &WebSocketProvider{BaseProvider: base}, nil
+	case ProviderGRPC:
+		return &GRPCProvider{BaseProvider: base}, nil
+	case ProviderGraphQL:
+		return &GraphQLProvider{BaseProvider: base}, nil
+	case ProviderTCP:
+		return &TCPProvider{BaseProvider: base}, nil
+	case ProviderUDP:
+		return &UDPProvider{BaseProvider: base}, nil
+	case ProviderWebRTC:
+		return &WebRTCProvider{BaseProvider: base}, nil
+	case ProviderMCP:
+		return &MCPProvider{}, nil
+	case ProviderText:
+		return &TextProvider{BaseProvider: base}, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider type %q", providerType)
+	}
+}

--- a/src/providers/helpers/unmarshal_test.go
+++ b/src/providers/helpers/unmarshal_test.go
@@ -132,3 +132,37 @@ func TestUnmarshalAuth_Errors(t *testing.T) {
 		t.Fatalf("expected json error")
 	}
 }
+
+func TestNewProviderInitializesType(t *testing.T) {
+	providerTypes := []ProviderType{
+		ProviderHTTP,
+		ProviderSSE,
+		ProviderHTTPStream,
+		ProviderCLI,
+		ProviderWebSocket,
+		ProviderGRPC,
+		ProviderGraphQL,
+		ProviderTCP,
+		ProviderUDP,
+		ProviderWebRTC,
+		ProviderMCP,
+		ProviderText,
+	}
+
+	for _, providerType := range providerTypes {
+		providerType := providerType
+		t.Run(string(providerType), func(t *testing.T) {
+			provider, err := NewProvider(providerType)
+			if err != nil {
+				t.Fatalf("NewProvider(%q) returned error: %v", providerType, err)
+			}
+			if got := provider.Type(); got != providerType {
+				t.Fatalf("NewProvider(%q).Type() = %q, want %q", providerType, got, providerType)
+			}
+		})
+	}
+
+	if _, err := NewProvider(ProviderType("unknown")); err == nil {
+		t.Fatal("NewProvider accepted an unknown provider type")
+	}
+}

--- a/src/repository/repo.go
+++ b/src/repository/repo.go
@@ -3,30 +3,23 @@ package repository
 import (
 	"context"
 	"fmt"
-
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
-
 	"sync"
 
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/graphql"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/grpc"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/mcp"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/sse"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/streamable"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/tcp"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/text"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/udp"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/webrtc"
-	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/websocket"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	providerhelpers "github.com/universal-tool-calling-protocol/go-utcp/src/providers/helpers"
+	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 )
 
 type InMemoryToolRepository struct {
-	Tools     map[string][]Tool   // providerName -> tools
-	Providers map[string]Provider // providerName -> Provider
-	mu        sync.RWMutex        // for concurrent access
+	// Tools and Providers remain exported for source compatibility. Treat them as
+	// read-only after the first repository operation; mutate through the methods.
+	Tools     map[string][]Tool
+	Providers map[string]Provider
+
+	mu            sync.RWMutex
+	toolIndex     map[string]Tool
+	toolProviders map[string]string
+	toolCount     int
 }
 
 func (r *InMemoryToolRepository) GetProvider(ctx context.Context, providerName string) (*Provider, error) {
@@ -42,7 +35,7 @@ func (r *InMemoryToolRepository) GetProvider(ctx context.Context, providerName s
 func (r *InMemoryToolRepository) GetProviders(ctx context.Context) ([]Provider, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	var providers []Provider
+	providers := make([]Provider, 0, len(r.Providers))
 	for _, p := range r.Providers {
 		providers = append(providers, p)
 	}
@@ -50,22 +43,21 @@ func (r *InMemoryToolRepository) GetProviders(ctx context.Context) ([]Provider, 
 }
 
 func (r *InMemoryToolRepository) GetTool(ctx context.Context, toolName string) (*Tool, error) {
+	r.ensureIndex()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for _, tools := range r.Tools {
-		for _, tool := range tools {
-			if tool.Name == toolName {
-				return &tool, nil
-			}
-		}
+	tool, ok := r.toolIndex[toolName]
+	if !ok {
+		return nil, nil
 	}
-	return nil, nil
+	return &tool, nil
 }
 
 func (r *InMemoryToolRepository) GetTools(ctx context.Context) ([]Tool, error) {
+	r.ensureIndex()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	var all []Tool
+	all := make([]Tool, 0, r.toolCount)
 	for _, tools := range r.Tools {
 		all = append(all, tools...)
 	}
@@ -79,7 +71,7 @@ func (r *InMemoryToolRepository) GetToolsByProvider(ctx context.Context, provide
 	if !ok {
 		return nil, fmt.Errorf("no tools found for provider %s", providerName)
 	}
-	return tools, nil
+	return append([]Tool(nil), tools...), nil
 }
 
 func (r *InMemoryToolRepository) RemoveProvider(ctx context.Context, providerName string) error {
@@ -88,21 +80,37 @@ func (r *InMemoryToolRepository) RemoveProvider(ctx context.Context, providerNam
 	if _, ok := r.Providers[providerName]; !ok {
 		return fmt.Errorf("provider not found: %s", providerName)
 	}
-	delete(r.Providers, providerName)
+	r.ensureIndexLocked()
+	for _, tool := range r.Tools[providerName] {
+		delete(r.toolIndex, tool.Name)
+		delete(r.toolProviders, tool.Name)
+		r.toolCount--
+	}
 	delete(r.Tools, providerName)
+	delete(r.Providers, providerName)
 	return nil
 }
 
 func (r *InMemoryToolRepository) RemoveTool(ctx context.Context, toolName string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for providerName, tools := range r.Tools {
-		for i, tool := range tools {
-			if tool.Name == toolName {
-				r.Tools[providerName] = append(tools[:i], tools[i+1:]...)
-				return nil
-			}
+	r.ensureIndexLocked()
+	providerName, ok := r.toolProviders[toolName]
+	if !ok {
+		return fmt.Errorf("tool not found: %s", toolName)
+	}
+	providerTools := r.Tools[providerName]
+	for i := range providerTools {
+		if providerTools[i].Name != toolName {
+			continue
 		}
+		copy(providerTools[i:], providerTools[i+1:])
+		providerTools[len(providerTools)-1] = Tool{}
+		r.Tools[providerName] = providerTools[:len(providerTools)-1]
+		delete(r.toolIndex, toolName)
+		delete(r.toolProviders, toolName)
+		r.toolCount--
+		return nil
 	}
 	return fmt.Errorf("tool not found: %s", toolName)
 }
@@ -115,37 +123,26 @@ func (r *InMemoryToolRepository) SaveProviderWithTools(ctx context.Context, prov
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	var providerName string
-	switch p := provider.(type) {
-	case *CliProvider:
-		providerName = p.Name
-	case *HttpProvider:
-		providerName = p.Name
-	case *SSEProvider:
-		providerName = p.Name
-	case *StreamableHttpProvider:
-		providerName = p.Name
-	case *WebSocketProvider:
-		providerName = p.Name
-	case *GRPCProvider:
-		providerName = p.Name
-	case *GraphQLProvider:
-		providerName = p.Name
-	case *TCPProvider:
-		providerName = p.Name
-	case *UDPProvider:
-		providerName = p.Name
-	case *WebRTCProvider:
-		providerName = p.Name
-	case *MCPProvider:
-		providerName = p.Name
-	case *TextProvider:
-		providerName = p.Name
-	default:
+	providerName, ok := providerhelpers.ProviderName(provider)
+	if !ok {
 		return fmt.Errorf("unsupported provider type for saving: %T", provider)
 	}
+	r.ensureIndexLocked()
+	if previous, exists := r.Tools[providerName]; exists {
+		for _, tool := range previous {
+			delete(r.toolIndex, tool.Name)
+			delete(r.toolProviders, tool.Name)
+		}
+		r.toolCount -= len(previous)
+	}
+	tools = append([]Tool(nil), tools...)
 	r.Providers[providerName] = provider
 	r.Tools[providerName] = tools
+	for _, tool := range tools {
+		r.toolIndex[tool.Name] = tool
+		r.toolProviders[tool.Name] = providerName
+	}
+	r.toolCount += len(tools)
 	return nil
 }
 
@@ -153,7 +150,40 @@ func NewInMemoryToolRepository() ToolRepository {
 	return &InMemoryToolRepository{
 		Tools:     make(map[string][]Tool),
 		Providers: make(map[string]Provider),
-		mu:        sync.RWMutex{},
+	}
+}
+
+func (r *InMemoryToolRepository) ensureIndex() {
+	r.mu.RLock()
+	ready := r.toolIndex != nil && r.toolProviders != nil
+	r.mu.RUnlock()
+	if ready {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ensureIndexLocked()
+}
+
+func (r *InMemoryToolRepository) ensureIndexLocked() {
+	if r.toolIndex != nil && r.toolProviders != nil {
+		return
+	}
+	if r.Tools == nil {
+		r.Tools = make(map[string][]Tool)
+	}
+	if r.Providers == nil {
+		r.Providers = make(map[string]Provider)
+	}
+	r.toolIndex = make(map[string]Tool)
+	r.toolProviders = make(map[string]string)
+	r.toolCount = 0
+	for providerName, providerTools := range r.Tools {
+		for _, tool := range providerTools {
+			r.toolIndex[tool.Name] = tool
+			r.toolProviders[tool.Name] = providerName
+			r.toolCount++
+		}
 	}
 }
 

--- a/src/repository/repo_benchmark_test.go
+++ b/src/repository/repo_benchmark_test.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/providers/cli"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/tools"
+)
+
+func benchmarkRepository(b *testing.B, providerCount, toolsPerProvider int) *InMemoryToolRepository {
+	b.Helper()
+	repo := NewInMemoryToolRepository().(*InMemoryToolRepository)
+	ctx := context.Background()
+	for providerIndex := 0; providerIndex < providerCount; providerIndex++ {
+		name := fmt.Sprintf("provider_%02d", providerIndex)
+		provider := &cli.CliProvider{BaseProvider: base.BaseProvider{Name: name, ProviderType: base.ProviderCLI}}
+		providerTools := make([]tools.Tool, toolsPerProvider)
+		for toolIndex := range providerTools {
+			providerTools[toolIndex].Name = fmt.Sprintf("%s.tool_%04d", name, toolIndex)
+		}
+		if err := repo.SaveProviderWithTools(ctx, provider, providerTools); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return repo
+}
+
+func BenchmarkInMemoryToolRepositoryGetTool(b *testing.B) {
+	repo := benchmarkRepository(b, 10, 100)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tool, err := repo.GetTool(ctx, "provider_09.tool_0099")
+		if err != nil || tool == nil {
+			b.Fatalf("lookup failed: tool=%v err=%v", tool, err)
+		}
+	}
+}
+
+func BenchmarkInMemoryToolRepositoryGetTools(b *testing.B) {
+	repo := benchmarkRepository(b, 10, 100)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		all, err := repo.GetTools(ctx)
+		if err != nil || len(all) != 1_000 {
+			b.Fatalf("list failed: count=%d err=%v", len(all), err)
+		}
+	}
+}

--- a/src/repository/repo_test.go
+++ b/src/repository/repo_test.go
@@ -35,8 +35,43 @@ func TestInMemoryToolRepository_CRUD(t *testing.T) {
 	if err := repo.RemoveTool(ctx, "echo"); err != nil {
 		t.Fatalf("remove tool failed: %v", err)
 	}
+	if tool, err := repo.GetTool(ctx, "echo"); err != nil || tool != nil {
+		t.Fatalf("removed tool remained indexed: tool=%v err=%v", tool, err)
+	}
 	if err := repo.RemoveProvider(ctx, "cli"); err != nil {
 		t.Fatalf("remove provider failed: %v", err)
+	}
+}
+
+func TestInMemoryToolRepository_ReplacesProviderIndex(t *testing.T) {
+	repo := NewInMemoryToolRepository().(*InMemoryToolRepository)
+	ctx := context.Background()
+	provider := &cli.CliProvider{BaseProvider: BaseProvider{Name: "cli", ProviderType: ProviderCLI}}
+	if err := repo.SaveProviderWithTools(ctx, provider, []Tool{{Name: "cli.old"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveProviderWithTools(ctx, provider, []Tool{{Name: "cli.new"}}); err != nil {
+		t.Fatal(err)
+	}
+	if old, _ := repo.GetTool(ctx, "cli.old"); old != nil {
+		t.Fatalf("replaced tool remained indexed: %+v", old)
+	}
+	if current, _ := repo.GetTool(ctx, "cli.new"); current == nil {
+		t.Fatal("replacement tool was not indexed")
+	}
+}
+
+func TestInMemoryToolRepository_IndexesLegacyInitialMapWrites(t *testing.T) {
+	repo := NewInMemoryToolRepository().(*InMemoryToolRepository)
+	provider := &cli.CliProvider{BaseProvider: BaseProvider{Name: "cli", ProviderType: ProviderCLI}}
+	repo.Providers["cli"] = provider
+	repo.Tools["cli"] = []Tool{{Name: "cli.old"}}
+
+	if tool, _ := repo.GetTool(context.Background(), "cli.old"); tool == nil {
+		t.Fatal("directly populated tool was not indexed")
+	}
+	if err := repo.RemoveProvider(context.Background(), "cli"); err != nil {
+		t.Fatalf("remove after direct map writes failed: %v", err)
 	}
 }
 

--- a/src/tag/tag_search.go
+++ b/src/tag/tag_search.go
@@ -2,9 +2,9 @@ package tag
 
 import (
 	"context"
-	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
 
@@ -15,7 +15,6 @@ import (
 type TagSearchStrategy struct {
 	toolRepository    ToolRepository
 	descriptionWeight float64
-	wordRegex         *regexp.Regexp
 }
 
 // NewTagSearchStrategy creates a new TagSearchStrategy with the given repository and description weight.
@@ -23,94 +22,145 @@ func NewTagSearchStrategy(repo ToolRepository, descriptionWeight float64) *TagSe
 	return &TagSearchStrategy{
 		toolRepository:    repo,
 		descriptionWeight: descriptionWeight,
-		wordRegex:         regexp.MustCompile(`\w+`),
 	}
+}
+
+type scoredTool struct {
+	index int
+	score float64
 }
 
 // SearchTools returns tools ordered by relevance to the query, using explicit tags and description keywords.
 func (s *TagSearchStrategy) SearchTools(ctx context.Context, query string, limit int) ([]Tool, error) {
-	// Normalize query
 	queryLower := strings.ToLower(strings.TrimSpace(query))
-	words := s.wordRegex.FindAllString(queryLower, -1)
-	queryWordSet := make(map[string]struct{}, len(words))
-	for _, w := range words {
-		queryWordSet[w] = struct{}{}
-	}
+	queryWordSet := wordSet(queryLower)
 
-	// Retrieve all tools
-	tools, err := s.toolRepository.GetTools(context.Background())
+	tools, err := s.toolRepository.GetTools(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Compute SUTCP score for each tool
-	type scoredTool struct {
-		tool  Tool
-		score float64
+	if len(tools) == 0 {
+		return nil, nil
 	}
-	var scored []scoredTool
 
-	for _, t := range tools {
+	resultLimit := limit
+	if resultLimit <= 0 || resultLimit > len(tools) {
+		resultLimit = len(tools)
+	}
+	useTopK := resultLimit <= 64 && resultLimit*4 < len(tools)
+	capacity := len(tools)
+	if useTopK {
+		capacity = resultLimit
+	}
+	selected := make([]scoredTool, 0, capacity)
+
+	for index, tool := range tools {
+		if index&63 == 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+		}
 		var score float64
 
-		// Match against tags
-		for _, tag := range t.Tags {
+		for _, tag := range tool.Tags {
 			tagLower := strings.ToLower(tag)
-
-			// Direct substring match
-			if strings.Contains(queryLower, tagLower) {
+			if tagLower != "" && strings.Contains(queryLower, tagLower) {
 				score += 1.0
 			}
-
-			// Word-level overlap
-			tagWords := s.wordRegex.FindAllString(tagLower, -1)
-			for _, w := range tagWords {
-				if _, ok := queryWordSet[w]; ok {
-					score += s.descriptionWeight
-				}
-			}
+			score += matchingWordScore(tagLower, queryWordSet, 0, s.descriptionWeight)
 		}
 
-		// Match against description
-		if t.Description != "" {
-			descWords := s.wordRegex.FindAllString(strings.ToLower(t.Description), -1)
-			for _, w := range descWords {
-				if len(w) > 2 {
-					if _, ok := queryWordSet[w]; ok {
-						score += s.descriptionWeight
-					}
-				}
-			}
+		if tool.Description != "" {
+			score += matchingWordScore(strings.ToLower(tool.Description), queryWordSet, 3, s.descriptionWeight)
 		}
 
-		scored = append(scored, scoredTool{tool: t, score: score})
-	}
-
-	// Sort descending by score
-	sort.Slice(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
-	})
-
-	// Collect only positive matches
-	var result []Tool
-	for _, st := range scored {
-		if st.score > 0 {
-			result = append(result, st.tool)
-			if len(result) >= limit {
+		if score <= 0 {
+			continue
+		}
+		candidate := scoredTool{index: index, score: score}
+		if !useTopK {
+			selected = append(selected, candidate)
+			continue
+		}
+		position := len(selected)
+		for i := range selected {
+			if betterScoredTool(candidate, selected[i]) {
+				position = i
 				break
 			}
 		}
+		if position >= resultLimit {
+			continue
+		}
+		if len(selected) < resultLimit {
+			selected = append(selected, scoredTool{})
+		}
+		copy(selected[position+1:], selected[position:len(selected)-1])
+		selected[position] = candidate
 	}
 
-	// If no matches, fallback to top N (for discoverability)
-	if len(result) == 0 && len(scored) > 0 {
-		for i, st := range scored {
-			if i >= limit {
-				break
-			}
-			result = append(result, st.tool)
+	if len(selected) == 0 {
+		return append([]Tool(nil), tools[:resultLimit]...), nil
+	}
+	if !useTopK {
+		sort.SliceStable(selected, func(i, j int) bool {
+			return betterScoredTool(selected[i], selected[j])
+		})
+		if len(selected) > resultLimit {
+			selected = selected[:resultLimit]
 		}
+	}
+
+	result := make([]Tool, len(selected))
+	for i, candidate := range selected {
+		result[i] = tools[candidate.index]
 	}
 
 	return result, nil
+}
+
+func betterScoredTool(left, right scoredTool) bool {
+	return left.score > right.score || left.score == right.score && left.index < right.index
+}
+
+func wordSet(value string) map[string]struct{} {
+	words := make(map[string]struct{})
+	forEachWord(value, func(word string) {
+		words[word] = struct{}{}
+	})
+	return words
+}
+
+func matchingWordScore(value string, queryWords map[string]struct{}, minLength int, weight float64) float64 {
+	var score float64
+	forEachWord(value, func(word string) {
+		if len(word) < minLength {
+			return
+		}
+		if _, ok := queryWords[word]; ok {
+			score += weight
+		}
+	})
+	return score
+}
+
+func forEachWord(value string, visit func(string)) {
+	start := -1
+	for index, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			if start < 0 {
+				start = index
+			}
+			continue
+		}
+		if start >= 0 {
+			visit(value[start:index])
+			start = -1
+		}
+	}
+	if start >= 0 {
+		visit(value[start:])
+	}
 }

--- a/src/tag/tag_search_test.go
+++ b/src/tag/tag_search_test.go
@@ -2,6 +2,7 @@ package tag
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -30,6 +31,29 @@ func TestTagSearchStrategy_SearchTools(t *testing.T) {
 		t.Fatalf("unexpected search result %v %v", res, err)
 	}
 }
+
+func TestTagSearchStrategy_UnlimitedAndCancelled(t *testing.T) {
+	repo := &InMemoryToolRepository{
+		Tools: map[string][]Tool{
+			"p": {
+				{Name: "p.t1", Tags: []string{"alpha"}},
+				{Name: "p.t2", Tags: []string{"alpha"}},
+			},
+		},
+		Providers: map[string]Provider{},
+	}
+	strategy := NewTagSearchStrategy(repo, 0.5)
+	results, err := strategy.SearchTools(context.Background(), "alpha", 0)
+	if err != nil || len(results) != 2 {
+		t.Fatalf("unlimited search returned %d results: %v", len(results), err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := strategy.SearchTools(ctx, "alpha", 1); err == nil {
+		t.Fatal("expected cancelled search to fail")
+	}
+}
 func TestDecodeToolsResponse(t *testing.T) {
 	r := io.NopCloser(strings.NewReader(`{"tools":[{"name":"t"}]}`))
 	tools, err := DecodeToolsResponse(r)
@@ -37,3 +61,34 @@ func TestDecodeToolsResponse(t *testing.T) {
 		t.Fatalf("decode err %v %v", tools, err)
 	}
 }
+
+func BenchmarkTagSearchStrategySearchTools(b *testing.B) {
+	repo := NewInMemoryToolRepository()
+	ctx := context.Background()
+	for providerIndex := 0; providerIndex < 10; providerIndex++ {
+		name := fmt.Sprintf("provider_%02d", providerIndex)
+		provider := &benchmarkProvider{BaseProvider{Name: name, ProviderType: ProviderType("benchmark")}}
+		providerTools := make([]Tool, 100)
+		for toolIndex := range providerTools {
+			providerTools[toolIndex] = Tool{
+				Name:        fmt.Sprintf("%s.tool_%03d", name, toolIndex),
+				Description: "Search memory records and process matching documents",
+				Tags:        []string{"memory", "search", "documents"},
+			}
+		}
+		repo.(*InMemoryToolRepository).Providers[name] = provider
+		repo.(*InMemoryToolRepository).Tools[name] = providerTools
+	}
+	strategy := NewTagSearchStrategy(repo, 0.5)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		matches, err := strategy.SearchTools(ctx, "search memory documents", 16)
+		if err != nil || len(matches) != 16 {
+			b.Fatalf("search failed: matches=%d err=%v", len(matches), err)
+		}
+	}
+}
+
+type benchmarkProvider struct{ BaseProvider }

--- a/src/transports/http/http_transport.go
+++ b/src/transports/http/http_transport.go
@@ -1,17 +1,20 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	json "github.com/universal-tool-calling-protocol/go-utcp/src/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/auth"
+	"github.com/universal-tool-calling-protocol/go-utcp/src/openapi"
 	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
@@ -19,13 +22,14 @@ import (
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/http"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tools"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // HttpClientTransport implements ClientTransportInterface for HTTP-based tool providers.
 type HttpClientTransport struct {
 	httpClient  *http.Client
 	oauthTokens map[string]map[string]interface{}
+	oauthMu     sync.RWMutex
 	logger      func(format string, args ...interface{})
 }
 
@@ -77,17 +81,24 @@ func (t *HttpClientTransport) applyAuth(req *http.Request, provider *HttpProvide
 
 // handleOAuth2 performs client credentials flow for OAuth2.
 func (t *HttpClientTransport) handleOAuth2(ctx context.Context, oauth *OAuth2Auth) (string, error) {
+	t.oauthMu.RLock()
 	if tokenData, ok := t.oauthTokens[oauth.ClientID]; ok {
 		if access, exists := tokenData["access_token"].(string); exists {
+			t.oauthMu.RUnlock()
 			return access, nil
 		}
+	}
+	t.oauthMu.RUnlock()
+	scope := ""
+	if oauth.Scope != nil {
+		scope = *oauth.Scope
 	}
 	// Try credentials in body
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
 	form.Set("client_id", oauth.ClientID)
 	form.Set("client_secret", oauth.ClientSecret)
-	form.Set("scope", *oauth.Scope)
+	form.Set("scope", scope)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauth.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -95,18 +106,24 @@ func (t *HttpClientTransport) handleOAuth2(ctx context.Context, oauth *OAuth2Aut
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := t.httpClient.Do(req)
-	if err == nil && resp.StatusCode < 300 {
-		defer resp.Body.Close()
+	if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		var data map[string]interface{}
 		if err := json.NewDecoder(resp.Body).Decode(&data); err == nil {
+			resp.Body.Close()
+			t.oauthMu.Lock()
 			t.oauthTokens[oauth.ClientID] = data
+			t.oauthMu.Unlock()
 			if tok, ok := data["access_token"].(string); ok {
 				return tok, nil
 			}
 		}
 	}
+	if err == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 	// Fallback: Basic Auth header
-	req2, err := http.NewRequestWithContext(ctx, http.MethodPost, oauth.TokenURL, strings.NewReader("grant_type=client_credentials&scope="+url.QueryEscape(*oauth.Scope)))
+	req2, err := http.NewRequestWithContext(ctx, http.MethodPost, oauth.TokenURL, strings.NewReader("grant_type=client_credentials&scope="+url.QueryEscape(scope)))
 	if err != nil {
 		return "", err
 	}
@@ -117,11 +134,17 @@ func (t *HttpClientTransport) handleOAuth2(ctx context.Context, oauth *OAuth2Aut
 		return "", err
 	}
 	defer resp2.Body.Close()
+	if resp2.StatusCode < 200 || resp2.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp2.Body, 4<<10))
+		return "", fmt.Errorf("OAuth2 token endpoint returned %s: %s", resp2.Status, body)
+	}
 	var data2 map[string]interface{}
 	if err := json.NewDecoder(resp2.Body).Decode(&data2); err != nil {
 		return "", err
 	}
+	t.oauthMu.Lock()
 	t.oauthTokens[oauth.ClientID] = data2
+	t.oauthMu.Unlock()
 	if tok, ok := data2["access_token"].(string); ok {
 		return tok, nil
 	}
@@ -166,36 +189,36 @@ func (t *HttpClientTransport) RegisterToolProvider(ctx context.Context, p Provid
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		t.logger("Error connecting to %s: %v", hp.Name, err)
-		return nil, nil
+		return nil, fmt.Errorf("connect to provider %q: %w", hp.Name, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		t.logger("Error response from %s: %s", hp.Name, resp.Status)
-		return nil, nil
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return nil, fmt.Errorf("provider %q returned %s: %s", hp.Name, resp.Status, body)
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
-	var raw interface{}
+	var raw map[string]interface{}
 	ct := resp.Header.Get("Content-Type")
 	if strings.Contains(ct, "yaml") || strings.HasSuffix(urlStr, ".yaml") || strings.HasSuffix(urlStr, ".yml") {
-		yaml.Unmarshal(bodyBytes, &raw)
+		if err := yaml.Unmarshal(bodyBytes, &raw); err != nil {
+			return nil, fmt.Errorf("decode provider %q YAML: %w", hp.Name, err)
+		}
 	} else {
-		json.Unmarshal(bodyBytes, &raw)
-	}
-	// Parse UTCP manual
-	var manual UtcpManual
-	mmap, ok := raw.(map[string]interface{})
-	if ok {
-		if _, hasVer := mmap["version"]; hasVer {
-			manual = NewUtcpManualFromMap(mmap)
-		} else {
-			converter := NewOpenAPIConverter(raw, hp.URL, hp.Name)
-			manual = converter.Convert()
+		if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+			return nil, fmt.Errorf("decode provider %q JSON: %w", hp.Name, err)
 		}
 	}
-	return manual.Tools, nil
+	if _, isUTCPManual := raw["version"]; isUTCPManual {
+		return NewUtcpManualFromMap(raw).Tools, nil
+	}
+	specURL := urlStr
+	if resp.Request != nil && resp.Request.URL != nil {
+		specURL = resp.Request.URL.String()
+	}
+	return openapi.NewConverter(raw, specURL, hp.Name).Convert().Tools, nil
 }
 
 // CallTool calls a specific tool on the HTTP provider.
@@ -205,15 +228,25 @@ func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, arg
 		return nil, errors.New("HttpTransport can only be used with HttpProvider")
 	}
 
-	// Use the URL as-is from the provider - this allows flexibility in URL patterns
 	urlTemplate := hp.URL
-
-	// Handle URL template substitution for path parameters
+	var pathArguments map[string]struct{}
 	for key, val := range args {
-		placeholder := fmt.Sprintf("{%s}", key)
+		placeholder := "{" + key + "}"
 		if strings.Contains(urlTemplate, placeholder) {
-			urlTemplate = strings.ReplaceAll(urlTemplate, placeholder, fmt.Sprintf("%v", val))
-			delete(args, key)
+			urlTemplate = strings.ReplaceAll(urlTemplate, placeholder, fmt.Sprint(val))
+			if pathArguments == nil {
+				pathArguments = make(map[string]struct{})
+			}
+			pathArguments[key] = struct{}{}
+		}
+	}
+	requestArgs := args
+	if len(pathArguments) > 0 {
+		requestArgs = make(map[string]any, len(args)-len(pathArguments))
+		for key, value := range args {
+			if _, usedInPath := pathArguments[key]; !usedInPath {
+				requestArgs[key] = value
+			}
 		}
 	}
 
@@ -225,13 +258,13 @@ func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, arg
 	var req *http.Request
 
 	// Determine request method and body based on remaining args and HTTP method
-	if len(args) > 0 && hp.HTTPMethod == "POST" {
+	if len(requestArgs) > 0 && hp.HTTPMethod == http.MethodPost {
 		// POST with JSON body
-		jsonData, err := json.Marshal(args)
+		jsonData, err := json.Marshal(requestArgs)
 		if err != nil {
 			return nil, err
 		}
-		req, err = http.NewRequestWithContext(ctx, hp.HTTPMethod, u.String(), strings.NewReader(string(jsonData)))
+		req, err = http.NewRequestWithContext(ctx, hp.HTTPMethod, u.String(), bytes.NewReader(jsonData))
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +273,7 @@ func (t *HttpClientTransport) CallTool(ctx context.Context, toolName string, arg
 	} else {
 		// GET or POST with query parameters
 		q := u.Query()
-		for k, v := range args {
+		for k, v := range requestArgs {
 			q.Set(k, fmt.Sprintf("%v", v))
 		}
 		u.RawQuery = q.Encode()

--- a/src/transports/http/http_transport_additional_test.go
+++ b/src/transports/http/http_transport_additional_test.go
@@ -41,12 +41,16 @@ func TestHttpTransport_CallTool_PathSub(t *testing.T) {
 	defer server.Close()
 	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL + "/{id}"}
 	tr := NewHttpClientTransport(nil)
-	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov, nil)
+	args := map[string]any{"id": 5}
+	res, err := tr.CallTool(context.Background(), "t", args, prov, nil)
 	if err != nil {
 		t.Fatalf("call error: %v", err)
 	}
 	if gotPath != "/5" {
 		t.Fatalf("path substitution failed: %s", gotPath)
+	}
+	if args["id"] != 5 {
+		t.Fatalf("CallTool mutated caller arguments: %#v", args)
 	}
 	m := res.(map[string]interface{})
 	if m["ok"] != true {

--- a/src/transports/mcp/mcp_transport.go
+++ b/src/transports/mcp/mcp_transport.go
@@ -894,8 +894,12 @@ func (t *MCPTransport) callHTTPTool(
 	if err != nil {
 		return nil, fmt.Errorf("HTTP call to tool '%s' failed: %w", toolName, err)
 	}
+	if len(res.Content) > 0 {
+		if content, err := contentAsMap(res.Content[0]); err == nil {
+			return content, nil
+		}
+	}
 
-	// Marshal the response to JSON bytes
 	raw, err := json.Marshal(res)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal response for tool '%s': %w", toolName, err)
@@ -915,6 +919,25 @@ func (t *MCPTransport) callHTTPTool(
 
 	// otherwise, fall back to the whole map
 	return respMap, nil
+}
+
+func contentAsMap(content mcpapi.Content) (map[string]any, error) {
+	switch value := content.(type) {
+	case mcpapi.TextContent:
+		return map[string]any{"type": value.Type, "text": value.Text}, nil
+	case *mcpapi.TextContent:
+		return map[string]any{"type": value.Type, "text": value.Text}, nil
+	}
+
+	raw, err := json.Marshal(content)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // extractContentMap unwraps a {"content":…} envelope and

--- a/src/transports/mcp/mcp_transport_http_test.go
+++ b/src/transports/mcp/mcp_transport_http_test.go
@@ -57,7 +57,7 @@ func TestMCPHTTPNonStreamReturnsMap(t *testing.T) {
 	}
 	log.Println(m)
 	content, ok := m["text"]
-	if !ok && content != "Hello, Go!" {
+	if !ok || content != "Hello, Go!" {
 		t.Fatalf("unexpected result: %#v", m)
 	}
 

--- a/src/transports/sse/sse_client_transport.go
+++ b/src/transports/sse/sse_client_transport.go
@@ -139,21 +139,32 @@ func (t *SSEClientTransport) CallTool(ctx context.Context, toolName string, args
 
 // handleSSEStream creates a streaming result using NewChannelStreamResult
 func (t *SSEClientTransport) handleSSEStream(ctx context.Context, body io.ReadCloser) (transports.StreamResult, error) {
-	eventChan := make(chan any, 10) // buffered channel to prevent blocking
+	streamCtx, cancel := context.WithCancel(ctx)
+	eventChan := make(chan any, 10)
 
-	// Start a goroutine to read SSE events and send them to the channel
 	go func() {
 		defer close(eventChan)
 		defer body.Close()
+		defer cancel()
+		send := func(value any) bool {
+			select {
+			case eventChan <- value:
+				return true
+			case <-streamCtx.Done():
+				return false
+			}
+		}
 
 		reader := bufio.NewReader(body)
 		var dataBuf strings.Builder
 
 		for {
 			select {
-			case <-ctx.Done():
-				// Context cancelled, send error and return
-				eventChan <- ctx.Err()
+			case <-streamCtx.Done():
+				select {
+				case eventChan <- streamCtx.Err():
+				default:
+				}
 				return
 			default:
 			}
@@ -163,7 +174,7 @@ func (t *SSEClientTransport) handleSSEStream(ctx context.Context, body io.ReadCl
 				if err == io.EOF {
 					return
 				}
-				eventChan <- err
+				send(err)
 				return
 			}
 			line = strings.TrimRight(line, "\r\n")
@@ -181,11 +192,13 @@ func (t *SSEClientTransport) handleSSEStream(ctx context.Context, body io.ReadCl
 					var evt interface{}
 					if err := json.Unmarshal([]byte(dataBuf.String()), &evt); err != nil {
 						t.logger("failed to unmarshal SSE data: %v", err)
-						eventChan <- err
+						send(err)
 						return
 					} else {
 						t.logger("Received SSE event: %v", evt)
-						eventChan <- evt
+						if !send(evt) {
+							return
+						}
 					}
 					dataBuf.Reset()
 				}
@@ -202,13 +215,10 @@ func (t *SSEClientTransport) handleSSEStream(ctx context.Context, body io.ReadCl
 		}
 	}()
 
-	// Create a close function that will close the body if needed
-	closeFn := func() error {
-		// The body will be closed by the goroutine, but we can cancel context here if needed
-		return nil
-	}
-
-	return transports.NewChannelStreamResult(eventChan, closeFn), nil
+	return transports.NewChannelStreamResult(eventChan, func() error {
+		cancel()
+		return body.Close()
+	}), nil
 }
 
 // Legacy method for backward compatibility - now returns slice from stream
@@ -267,5 +277,12 @@ func (t *SSEClientTransport) CallToolStream(
 	args map[string]any,
 	p Provider,
 ) (transports.StreamResult, error) {
-	return nil, errors.New("streaming is supported by SSEClientTransport, use CallTool")
+	result, err := t.CallTool(ctx, toolName, args, p, nil)
+	if err != nil {
+		return nil, err
+	}
+	if stream, ok := result.(transports.StreamResult); ok {
+		return stream, nil
+	}
+	return transports.NewSliceStreamResult([]any{result}, nil), nil
 }

--- a/src/transports/sse/sse_client_transport_additional2_test.go
+++ b/src/transports/sse/sse_client_transport_additional2_test.go
@@ -1,9 +1,11 @@
 package sse
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleSSE(t *testing.T) {
@@ -17,5 +19,38 @@ func TestHandleSSE(t *testing.T) {
 	}
 	if len(events) != 2 {
 		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+}
+
+type closeCountingReader struct {
+	io.Reader
+	closed chan struct{}
+}
+
+func (r *closeCountingReader) Close() error {
+	r.closed <- struct{}{}
+	return nil
+}
+
+func TestSSEStreamCloseUnblocksFullBuffer(t *testing.T) {
+	closed := make(chan struct{}, 2)
+	body := &closeCountingReader{
+		Reader: strings.NewReader(strings.Repeat("data: {\"n\":1}\n\n", 32)),
+		closed: closed,
+	}
+	stream, err := NewSSETransport(nil).handleSSEStream(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Fatal("stream producer did not exit after Close")
+		}
 	}
 }

--- a/src/transports/streamable/streamable_transport.go
+++ b/src/transports/streamable/streamable_transport.go
@@ -1,7 +1,6 @@
 package streamable
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -22,18 +21,21 @@ import (
 // It can stream NDJSON or JSON Sequence responses, emitting each chunk via logger
 // and updating the last-chunk pointer if provided.
 type StreamableHTTPClientTransport struct {
-	client *http.Client
-	logger func(format string, args ...interface{})
+	client  *http.Client
+	logger  func(format string, args ...interface{})
+	logging bool
 }
 
 // NewStreamableHTTPTransport constructs a new StreamableHTTPClientTransport.
 func NewStreamableHTTPTransport(logger func(format string, args ...interface{})) *StreamableHTTPClientTransport {
+	logging := logger != nil
 	if logger == nil {
 		logger = func(format string, args ...interface{}) {}
 	}
 	return &StreamableHTTPClientTransport{
-		client: &http.Client{Timeout: 30 * time.Second},
-		logger: logger,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		logger:  logger,
+		logging: logging,
 	}
 }
 
@@ -56,7 +58,11 @@ func (t *StreamableHTTPClientTransport) RegisterToolProvider(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return nil, fmt.Errorf("register provider %q: %s: %s", streamProv.Name, resp.Status, body)
+	}
 
 	return DecodeToolsResponse(resp.Body)
 }
@@ -95,79 +101,83 @@ func (t *StreamableHTTPClientTransport) CallTool(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return nil, fmt.Errorf("call tool %q: %s: %s", toolName, resp.Status, body)
+	}
 
-	// Use a buffered reader to handle NDJSON or JSON Sequence
-	reader := bufio.NewReader(resp.Body)
-	dec := json.NewDecoder(reader)
+	dec := json.NewDecoder(resp.Body)
+	streamCtx, cancel := context.WithCancel(ctx)
+	resultCh := make(chan any, 10)
 
-	// Create a channel for streaming results
-	resultCh := make(chan any, 10) // Buffer to prevent blocking
-
-	// Start a goroutine to process the stream
 	go func() {
 		defer close(resultCh)
 		defer resp.Body.Close()
+		defer cancel()
+		send := func(value any) bool {
+			select {
+			case resultCh <- value:
+				return true
+			case <-streamCtx.Done():
+				return false
+			}
+		}
 
 		for {
-			// Check if context is cancelled
 			select {
-			case <-ctx.Done():
-				resultCh <- ctx.Err()
+			case <-streamCtx.Done():
+				select {
+				case resultCh <- streamCtx.Err():
+				default:
+				}
 				return
 			default:
 			}
 
-			// Peek to see if there's any data left
-			b, err := reader.Peek(1)
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				resultCh <- err
-				return
-			}
-			// Skip empty whitespace
-			if len(b) == 1 && (b[0] == '\n' || b[0] == ' ' || b[0] == '\t' || b[0] == '\r') {
-				reader.ReadByte()
-				continue
-			}
-
-			var raw json.RawMessage
-			if err := dec.Decode(&raw); err != nil {
-				if err == io.EOF {
-					break
-				}
-				resultCh <- err
-				return
-			}
-
-			// Log the raw JSON chunk
-			rawStr := string(bytes.TrimSpace(raw))
-			t.logger("received chunk: %s", rawStr)
-			if l != nil {
-				*l = rawStr
-			}
-
-			// Unmarshal into interface{}
 			var obj interface{}
-			if err := json.Unmarshal(raw, &obj); err != nil {
-				resultCh <- err
+			if t.logging || l != nil {
+				var raw json.RawMessage
+				if err := dec.Decode(&raw); err != nil {
+					if err == io.EOF {
+						return
+					}
+					send(err)
+					return
+				}
+				rawString := string(bytes.TrimSpace(raw))
+				if t.logging {
+					t.logger("received chunk: %s", rawString)
+				}
+				if l != nil {
+					*l = rawString
+				}
+				if err := json.Unmarshal(raw, &obj); err != nil {
+					send(err)
+					return
+				}
+			} else if err := dec.Decode(&obj); err != nil {
+				if err == io.EOF {
+					return
+				}
+				send(err)
 				return
 			}
-			resultCh <- obj
+			if !send(obj) {
+				return
+			}
 		}
 	}()
 
-	// Return a ChannelStreamResult
 	streamResult := transports.NewChannelStreamResult(resultCh, func() error {
-		// The goroutine will handle closing the response body
-		return nil
+		cancel()
+		return resp.Body.Close()
 	})
 
 	return streamResult, nil
 }
 
-// CallToolStream is a new method that explicitly returns a StreamResult for streaming use cases.
-// This provides a cleaner API for consumers who want to handle streaming results.
+// CallToolStream invokes a tool and returns its streamed results.
 func (t *StreamableHTTPClientTransport) CallToolStream(
 	ctx context.Context,
 	toolName string,

--- a/src/transports/streamable/streamable_transport_test.go
+++ b/src/transports/streamable/streamable_transport_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/base"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/streamable"
@@ -77,6 +79,60 @@ func TestStreamableHTTPClientTransport_RegisterAndCall(t *testing.T) {
 	m, ok := result.(map[string]interface{})
 	if !ok || m["result"] != "hi" {
 		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+type closeCountingBody struct {
+	io.Reader
+	closed chan struct{}
+}
+
+func (b *closeCountingBody) Close() error {
+	b.closed <- struct{}{}
+	return nil
+}
+
+func TestStreamableCloseUnblocksFullBuffer(t *testing.T) {
+	closed := make(chan struct{}, 2)
+	body := &closeCountingBody{
+		Reader: strings.NewReader(strings.Repeat("{\"n\":1}\n", 32)),
+		closed: closed,
+	}
+	transport := NewStreamableHTTPTransport(nil)
+	transport.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       body,
+			Request:    request,
+		}, nil
+	})}
+	provider := &StreamableHttpProvider{
+		BaseProvider: BaseProvider{Name: "stream", ProviderType: ProviderHTTPStream},
+		URL:          "http://example.test",
+	}
+	result, err := transport.CallTool(context.Background(), "many", nil, provider, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := result.(transports.StreamResult)
+	time.Sleep(20 * time.Millisecond)
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Fatal("stream producer did not exit after Close")
+		}
 	}
 }
 

--- a/src/transports/tcp/tcp_transport.go
+++ b/src/transports/tcp/tcp_transport.go
@@ -1,13 +1,13 @@
 package tcp
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	json "github.com/universal-tool-calling-protocol/go-utcp/src/json"
 	"io"
 	"net"
+	"strconv"
 	"time"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
@@ -38,7 +38,7 @@ func (t *TCPClientTransport) dial(ctx context.Context, prov *TCPProvider) (net.C
 		timeout = 30000
 	}
 	d := net.Dialer{Timeout: timeout * time.Millisecond}
-	return d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", prov.Host, prov.Port))
+	return d.DialContext(ctx, "tcp", net.JoinHostPort(prov.Host, strconv.Itoa(prov.Port)))
 }
 
 // RegisterToolProvider connects to the TCP provider and retrieves its manual.
@@ -59,7 +59,7 @@ func (t *TCPClientTransport) RegisterToolProvider(ctx context.Context, prov Prov
 		return nil, err
 	}
 	var resp map[string]interface{}
-	if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&resp); err != nil {
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
 		return nil, err
 	}
 	manual := NewUtcpManualFromMap(resp)
@@ -95,7 +95,7 @@ func (t *TCPClientTransport) CallTool(ctx context.Context, toolName string, args
 	}
 
 	// Read the response
-	dec := json.NewDecoder(bufio.NewReader(conn))
+	dec := json.NewDecoder(conn)
 	var result any
 	if err := dec.Decode(&result); err != nil {
 		// If the peer just closed the socket without a payload, treat it as no result

--- a/src/transports/udp/udp_transport.go
+++ b/src/transports/udp/udp_transport.go
@@ -3,9 +3,10 @@ package udp
 import (
 	"context"
 	"errors"
-	"fmt"
 	json "github.com/universal-tool-calling-protocol/go-utcp/src/json"
 	"net"
+	"strconv"
+	"sync"
 
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/manual"
 	"github.com/universal-tool-calling-protocol/go-utcp/src/transports"
@@ -20,7 +21,8 @@ import (
 
 // UDPTransport implements the ClientTransport interface over UDP.
 type UDPTransport struct {
-	logger func(format string, args ...interface{})
+	logger  func(format string, args ...interface{})
+	buffers sync.Pool
 }
 
 // NewUDPTransport constructs a UDPTransport with optional logging.
@@ -28,12 +30,17 @@ func NewUDPTransport(logger func(format string, args ...interface{})) *UDPTransp
 	if logger == nil {
 		logger = func(string, ...interface{}) {}
 	}
-	return &UDPTransport{logger: logger}
+	transport := &UDPTransport{logger: logger}
+	transport.buffers.New = func() any {
+		buffer := make([]byte, 65_535)
+		return &buffer
+	}
+	return transport
 }
 
 // writeAndRead sends a packet and waits for a response within timeout.
 func (t *UDPTransport) writeAndRead(ctx context.Context, addr string, timeout time.Duration, payload []byte) ([]byte, error) {
-	conn, err := net.Dial("udp", addr)
+	conn, err := (&net.Dialer{}).DialContext(ctx, "udp", addr)
 	if err != nil {
 		return nil, err
 	}
@@ -46,12 +53,13 @@ func (t *UDPTransport) writeAndRead(ctx context.Context, addr string, timeout ti
 	if _, err := conn.Write(payload); err != nil {
 		return nil, err
 	}
-	buf := make([]byte, 65535)
-	n, err := conn.Read(buf)
+	buffer := t.buffers.Get().(*[]byte)
+	defer t.buffers.Put(buffer)
+	n, err := conn.Read(*buffer)
 	if err != nil {
 		return nil, err
 	}
-	return buf[:n], nil
+	return append([]byte(nil), (*buffer)[:n]...), nil
 }
 
 // RegisterToolProvider discovers tools by sending a DISCOVER message to the server.
@@ -60,7 +68,7 @@ func (t *UDPTransport) RegisterToolProvider(ctx context.Context, prov Provider) 
 	if !ok {
 		return nil, errors.New("UDPTransport can only be used with UDPProvider")
 	}
-	addr := fmt.Sprintf("%s:%d", p.Host, p.Port)
+	addr := net.JoinHostPort(p.Host, strconv.Itoa(p.Port))
 	timeout := time.Duration(p.Timeout) * time.Millisecond
 	resp, err := t.writeAndRead(ctx, addr, timeout, []byte("DISCOVER"))
 	if err != nil {
@@ -87,7 +95,7 @@ func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[s
 	if !ok {
 		return nil, errors.New("UDPTransport can only be used with UDPProvider")
 	}
-	addr := fmt.Sprintf("%s:%d", p.Host, p.Port)
+	addr := net.JoinHostPort(p.Host, strconv.Itoa(p.Port))
 	timeout := time.Duration(p.Timeout) * time.Millisecond
 	payload, err := json.Marshal(map[string]any{"tool": toolName, "args": args})
 	if err != nil {

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/universal-tool-calling-protocol/go-utcp/src/openapi"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/providers/helpers"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/repository"
 	. "github.com/universal-tool-calling-protocol/go-utcp/src/tag"
@@ -54,12 +53,6 @@ var json = jsoniter.ConfigFastest
 // Precompiled var substitution regex (avoids recompiling per call)
 var varRe = regexp.MustCompile(`\${(\w+)}|\$(\w+)`)
 
-// --- FAST PATH PRIMITIVES ---
-// We keep a read-optimized cache for tool resolution and inlined fast-callers to
-// remove per-call map lookups/allocs.
-type fastCaller func(ctx context.Context, args map[string]any) (any, error)
-type fastStreamCaller func(ctx context.Context, args map[string]any) (transports.StreamResult, error)
-
 // UtcpClientInterface defines the public API.
 type UtcpClientInterface interface {
 	RegisterToolProvider(ctx context.Context, prov Provider) ([]Tool, error)
@@ -74,7 +67,11 @@ type resolvedTool struct {
 	provider  Provider
 	transport ClientTransport
 	callName  string
-	tool      *Tool
+}
+
+type clientCache struct {
+	tools         map[string]*resolvedTool
+	providerTools map[string][]Tool
 }
 
 // UtcpClient holds all state and implements UtcpClientInterface.
@@ -84,16 +81,9 @@ type UtcpClient struct {
 	toolRepository ToolRepository
 	searchStrategy ToolSearchStrategy
 
-	// Legacy caches (used for invalidation + scans)
-	providerToolsCache    map[string][]Tool
-	providerToolsCacheMu  sync.RWMutex
-	toolResolutionCache   map[string]*resolvedTool // key is full tool name
-	toolResolutionCacheMu sync.RWMutex
-
-	// New caches
-	resolved sync.Map // map[string]*resolvedTool
-	callers  sync.Map // map[string]fastCaller
-	streams  sync.Map // map[string]fastStreamCaller
+	cacheMu  sync.Mutex
+	cache    atomic.Pointer[clientCache]
+	fallback sync.Map
 }
 
 // NewUTCPClient constructs a new client, loading providers if configured.
@@ -107,26 +97,19 @@ func NewUTCPClient(
 		cfg = NewClientConfig()
 	}
 	if repo == nil {
-		repo = NewInMemoryToolRepository() // You'll need to implement this
+		repo = NewInMemoryToolRepository()
 	}
 	if strat == nil {
-		strat = NewTagSearchStrategy(repo, 1.0) // You'll need to implement this
+		strat = NewTagSearchStrategy(repo, 1.0)
 	}
 
 	client := &UtcpClient{
-		config:              cfg,
-		transports:          defaultTransports(),
-		toolRepository:      repo,
-		searchStrategy:      strat,
-		providerToolsCache:  make(map[string][]Tool),
-		toolResolutionCache: make(map[string]*resolvedTool),
+		config:         cfg,
+		transports:     defaultTransports(),
+		toolRepository: repo,
+		searchStrategy: strat,
 	}
-
-	// If providersFilePath is set, we *used to* adjust a Text transport base path.
-	// Removed because there's no TextTransport in this codebase.
-	if cfg.ProvidersFilePath != "" {
-		_ = filepath.Dir(cfg.ProvidersFilePath) // keep import; may be useful later
-	}
+	client.cache.Store(newClientCache())
 
 	// eager variable substitution if inline vars present
 	if len(cfg.Variables) > 0 {
@@ -153,58 +136,22 @@ func NewUTCPClient(
 
 // defaultTransports wires up your various transport implementations.
 func defaultTransports() map[string]ClientTransport {
-	// NOTE: If runtime logging overhead shows up in profiles, consider passing no-op loggers here.
 	return map[string]ClientTransport{
-		"http": NewHttpClientTransport(
-			func(format string, args ...interface{}) {
-				fmt.Printf("HTTP Transport: "+format+"\n", args...)
-			},
-		),
-		"cli": NewCliTransport(
-			func(format string, args ...interface{}) {
-				fmt.Printf("CLI Transport: "+format+"\n", args...)
-			},
-		),
-		"sse": NewSSETransport(func(format string, args ...interface{}) {
-			fmt.Printf("SSE Transport: "+format+"\n", args...)
-		}),
-		"http_stream": NewStreamableHTTPTransport(func(format string, args ...interface{}) {
-			fmt.Printf("HTTP Stream Transport: "+format+"\n", args...)
-		}),
-		"mcp": NewMCPTransport(
-			func(format string, args ...interface{}) {
-				fmt.Printf("MCP Transport: "+format+"\n", args...)
-			},
-		),
-		"websocket": NewWebSocketTransport(func(format string, args ...interface{}) {
-			fmt.Printf("WebSocket Transport: "+format+"\n", args...)
-		}),
-		"tcp": NewTCPClientTransport(
-			func(format string, args ...interface{}) {
-				fmt.Printf("TCP Transport: "+format+"\n", args...)
-			},
-		),
-		"udp": NewUDPTransport(
-			func(format string, args ...interface{}) {
-				fmt.Printf("UDP Transport: "+format+"\n", args...)
-			},
-		),
-		"grpc": NewGRPCClientTransport(func(format string, args ...interface{}) {
-			fmt.Printf("gRPC Transport: "+format+"\n", args...)
-		}),
-		"graphql": NewGraphQLClientTransport(func(msg string, err error) {
-			fmt.Printf("GraphQL Transport: %s: %v\n", msg, err)
-		}),
-		"webrtc": NewWebRTCClientTransport(func(format string, args ...interface{}) {
-			fmt.Printf("WebRTC Transport: "+format+"\n", args...)
-		}),
-		"text": texttransport.NewTextTransport(func(format string, args ...interface{}) {
-			fmt.Printf("Text Transport: "+format+"\n", args...)
-		}),
+		"http":        NewHttpClientTransport(nil),
+		"cli":         NewCliTransport(nil),
+		"sse":         NewSSETransport(nil),
+		"http_stream": NewStreamableHTTPTransport(nil),
+		"mcp":         NewMCPTransport(nil),
+		"websocket":   NewWebSocketTransport(nil),
+		"tcp":         NewTCPClientTransport(nil),
+		"udp":         NewUDPTransport(nil),
+		"grpc":        NewGRPCClientTransport(nil),
+		"graphql":     NewGraphQLClientTransport(nil),
+		"webrtc":      NewWebRTCClientTransport(nil),
+		"text":        texttransport.NewTextTransport(nil),
 	}
 }
 
-// Updated loadProviders method using the new parser
 func (c *UtcpClient) loadProviders(ctx context.Context, path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -216,14 +163,12 @@ func (c *UtcpClient) loadProviders(ctx context.Context, path string) error {
 	}
 
 	var errors []string
-	successCount := 0
 
 	for i, raw := range rawList {
 		if err := c.processProvider(ctx, raw, i); err != nil {
 			errors = append(errors, fmt.Sprintf("provider %d: %v", i, err))
 			continue
 		}
-		successCount++
 	}
 	if len(errors) > 0 {
 		for _, errMsg := range errors {
@@ -231,84 +176,31 @@ func (c *UtcpClient) loadProviders(ctx context.Context, path string) error {
 		}
 	}
 
-	_ = successCount // Currently unused; keep for future logging/metrics
 	return nil
 }
 
 // getProviderName extracts the name from a provider
 func (c *UtcpClient) getProviderName(prov Provider) string {
-	switch p := prov.(type) {
-	case *HttpProvider:
-		return p.Name
-	case *CliProvider:
-		return p.Name
-	case *SSEProvider:
-		return p.Name
-	case *StreamableHttpProvider:
-		return p.Name
-	case *WebSocketProvider:
-		return p.Name
-	case *GRPCProvider:
-		return p.Name
-	case *GraphQLProvider:
-		return p.Name
-	case *TCPProvider:
-		return p.Name
-	case *UDPProvider:
-		return p.Name
-	case *WebRTCProvider:
-		return p.Name
-	case *MCPProvider:
-		return p.Name
-	case *TextProvider:
-		return p.Name
-	default:
-		return "unknown"
+	if name, ok := ProviderName(prov); ok {
+		return name
 	}
+	return "unknown"
 }
 
 // setProviderName sets the name on a provider
 func (c *UtcpClient) setProviderName(prov Provider, name string) {
-	switch p := prov.(type) {
-	case *HttpProvider:
-		p.Name = name
-	case *CliProvider:
-		p.Name = name
-	case *SSEProvider:
-		p.Name = name
-	case *StreamableHttpProvider:
-		p.Name = name
-	case *WebSocketProvider:
-		p.Name = name
-	case *GRPCProvider:
-		p.Name = name
-	case *GraphQLProvider:
-		p.Name = name
-	case *TCPProvider:
-		p.Name = name
-	case *UDPProvider:
-		p.Name = name
-	case *WebRTCProvider:
-		p.Name = name
-	case *MCPProvider:
-		p.Name = name
-	case *TextProvider:
-		p.Name = name
-	}
+	SetProviderName(prov, name)
 }
 
-// RegisterToolProvider applies variable substitution, picks the right transport, and registers tools.
 // RegisterToolProvider picks the transport and registers tools.
 // NOTE: do NOT call substituteProviderVariables here; processProvider already did it.
 func (c *UtcpClient) RegisterToolProvider(
 	ctx context.Context,
 	prov Provider,
 ) ([]Tool, error) {
-	c.ensureCaches()
-
 	// Derive/sanitize provider name with a safe fallback (prevents ".tool" cases).
 	name := strings.ReplaceAll(c.getProviderName(prov), ".", "_")
-	if name == "" {
+	if name == "" || name == "unknown" {
 		name = strings.ToLower(string(prov.Type()))
 		if name == "" {
 			name = "provider"
@@ -316,38 +208,9 @@ func (c *UtcpClient) RegisterToolProvider(
 	}
 	c.setProviderName(prov, name)
 
-	// Cache hit? Return and prime fast caches (S1005 fix: no blank identifier).
-	c.providerToolsCacheMu.RLock()
-	if tools, ok := c.providerToolsCache[name]; ok {
-		c.providerToolsCacheMu.RUnlock()
-
-		tr := c.transports[string(prov.Type())]
-		if tr == nil {
-			// Defensive: provider cached but transport missing; skip priming.
-			return tools, nil
-		}
-
-		c.toolResolutionCacheMu.Lock()
-		for i := range tools {
-			if _, exists := c.toolResolutionCache[tools[i].Name]; !exists {
-				callName := tools[i].Name
-				if prov.Type() == ProviderMCP || prov.Type() == ProviderText {
-					if _, suffix, ok := strings.Cut(tools[i].Name, "."); ok {
-						callName = suffix
-					}
-				}
-				res := &resolvedTool{provider: prov, transport: tr, callName: callName, tool: &tools[i]}
-				c.toolResolutionCache[tools[i].Name] = res
-				c.setResolvedSync(tools[i].Name, res)
-				c.setFastCallerSync(tools[i].Name, newFastCaller(prov, tr, callName))
-				c.setFastStreamCallerSync(tools[i].Name, newFastStreamCaller(prov, tr, callName))
-			}
-		}
-		c.toolResolutionCacheMu.Unlock()
-
+	if tools, ok := c.cachedProviderTools(name); ok {
 		return tools, nil
 	}
-	c.providerToolsCacheMu.RUnlock()
 
 	// Look up transport
 	tr, ok := c.transports[string(prov.Type())]
@@ -365,41 +228,9 @@ func (c *UtcpClient) RegisterToolProvider(
 		}
 	}
 
-	// Ask transport (HTTP may use OpenAPI converter)
-	var (
-		tools []Tool
-		err   error
-	)
-	if prov.Type() == ProviderHTTP {
-		if httpProv, ok := prov.(*HttpProvider); ok {
-			converter, convErr := openapi.NewConverterFromURL(httpProv.URL, "")
-			if convErr != nil {
-				tools, err = tr.RegisterToolProvider(ctx, prov) // fallback
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				manual := converter.Convert()
-				if len(manual.Tools) == 0 {
-					tools, err = tr.RegisterToolProvider(ctx, prov) // fallback
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					tools = manual.Tools
-				}
-			}
-		} else {
-			tools, err = tr.RegisterToolProvider(ctx, prov)
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		tools, err = tr.RegisterToolProvider(ctx, prov)
-		if err != nil {
-			return nil, err
-		}
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		return nil, err
 	}
 
 	// Normalize tool names so they are always qualified with this provider and never start with "."
@@ -421,29 +252,9 @@ func (c *UtcpClient) RegisterToolProvider(
 		return nil, err
 	}
 
-	// Cache provider tools
-	c.providerToolsCacheMu.Lock()
-	c.providerToolsCache[name] = tools
-	c.providerToolsCacheMu.Unlock()
+	c.publishProvider(name, prov, tr, tools)
 
-	// Prime resolution + fast-call caches
-	c.toolResolutionCacheMu.Lock()
-	for i := range tools {
-		callName := tools[i].Name
-		if prov.Type() == ProviderMCP || prov.Type() == ProviderText {
-			if _, suffix, ok := strings.Cut(tools[i].Name, "."); ok {
-				callName = suffix
-			}
-		}
-		res := &resolvedTool{provider: prov, transport: tr, callName: callName, tool: &tools[i]}
-		c.toolResolutionCache[tools[i].Name] = res
-		c.setResolvedSync(tools[i].Name, res)
-		c.setFastCallerSync(tools[i].Name, newFastCaller(prov, tr, callName))
-		c.setFastStreamCallerSync(tools[i].Name, newFastStreamCaller(prov, tr, callName))
-	}
-	c.toolResolutionCacheMu.Unlock()
-
-	return tools, nil
+	return append([]Tool(nil), tools...), nil
 }
 
 func (c *UtcpClient) DeregisterToolProvider(ctx context.Context, providerName string) error {
@@ -466,75 +277,48 @@ func (c *UtcpClient) DeregisterToolProvider(ctx context.Context, providerName st
 		return err
 	}
 
-	// Invalidate providerToolsCache
-	c.providerToolsCacheMu.Lock()
-	delete(c.providerToolsCache, providerName)
-	c.providerToolsCacheMu.Unlock()
-
-	// Invalidate resolution cache entries for tools of this provider
-	c.toolResolutionCacheMu.Lock()
-	for k, res := range c.toolResolutionCache {
-		// Assuming tool.Name has prefix providerName.
-		if strings.HasPrefix(k, providerName+".") {
-			delete(c.toolResolutionCache, k)
-			c.deleteFastCaches(k)
-		} else if res.provider != nil {
-			// Fallback check: if provider name matches
-			if c.getProviderName(res.provider) == providerName {
-				delete(c.toolResolutionCache, k)
-				c.deleteFastCaches(k)
-			}
-		}
-	}
-	c.toolResolutionCacheMu.Unlock()
+	c.removeCachedProvider(providerName)
 
 	return nil
 }
 
-// --- HOT PATH: CallTool with lock-free fast lookup ---
 func (c *UtcpClient) CallTool(
 	ctx context.Context,
 	toolName string,
 	args map[string]any,
 ) (any, error) {
-	// 1) Lock-free fast path: Try to fetch the fast-caller immediately
-	if fn, ok := c.getFastCaller(toolName); ok {
-		return fn(ctx, args)
-	}
-
-	// 2) Slow path: Resolve tool details and cache them for future use
-	prov, tr, callName, _, err := c.resolveTool(ctx, toolName)
+	resolved, err := c.resolveTool(ctx, toolName)
 	if err != nil {
 		return nil, err
 	}
-
-	// Use conditional locking or improved cache handling
-	var fn fastCaller
-	if fn, err = c.getOrCreateFastCaller(toolName, prov, tr, callName); err != nil {
-		return nil, err
-	}
-
-	return fn(ctx, args)
+	return resolved.transport.CallTool(ctx, resolved.callName, args, resolved.provider, nil)
 }
 
-func (c *UtcpClient) SearchTools(providerPrefix string, limit int) ([]Tool, error) {
-	// If providerPrefix is empty, return all tools.
-	if providerPrefix == "" {
-		return c.toolRepository.GetTools(context.Background())
+func (c *UtcpClient) SearchTools(query string, limit int) ([]Tool, error) {
+	ctx := context.Background()
+	if query == "" {
+		all, err := c.toolRepository.GetTools(ctx)
+		return limitTools(all, limit), err
 	}
 
-	all, err := c.toolRepository.GetTools(context.Background())
-	if err != nil {
+	if provider, err := c.toolRepository.GetProvider(ctx, query); err != nil {
 		return nil, err
+	} else if provider != nil {
+		providerTools, err := c.toolRepository.GetToolsByProvider(ctx, query)
+		return limitTools(providerTools, limit), err
 	}
 
-	var filtered []Tool
-	for _, t := range all {
-		if strings.HasPrefix(t.Name, providerPrefix+".") {
-			filtered = append(filtered, t)
-		}
+	if c.searchStrategy != nil {
+		return c.searchStrategy.SearchTools(ctx, query, limit)
 	}
-	return filtered, nil
+	return nil, nil
+}
+
+func limitTools(all []Tool, limit int) []Tool {
+	if limit <= 0 || len(all) <= limit {
+		return all
+	}
+	return all[:limit]
 }
 
 // ----- variable substitution src -----
@@ -610,34 +394,11 @@ func (c *UtcpClient) providerToMap(p Provider) map[string]any {
 
 // createProviderOfType creates a new provider instance of the given type
 func (c *UtcpClient) createProviderOfType(ptype ProviderType) Provider {
-	switch ptype {
-	case ProviderHTTP:
+	provider, err := NewProvider(ptype)
+	if err != nil {
 		return &HttpProvider{}
-	case ProviderCLI:
-		return &CliProvider{}
-	case ProviderSSE:
-		return &SSEProvider{}
-	case ProviderHTTPStream:
-		return &StreamableHttpProvider{}
-	case ProviderWebSocket:
-		return &WebSocketProvider{}
-	case ProviderGRPC:
-		return &GRPCProvider{}
-	case ProviderGraphQL:
-		return &GraphQLProvider{}
-	case ProviderTCP:
-		return &TCPProvider{}
-	case ProviderUDP:
-		return &UDPProvider{}
-	case ProviderWebRTC:
-		return &WebRTCProvider{}
-	case ProviderMCP:
-		return &MCPProvider{}
-	case ProviderText:
-		return &TextProvider{}
-	default:
-		return &HttpProvider{} // fallback
 	}
+	return provider
 }
 
 // replaceVarsInAny walks strings, maps, lists and does ${VAR}/$VAR substitution.
@@ -645,10 +406,9 @@ func (c *UtcpClient) replaceVarsInAny(x any, cfg *UtcpClientConfig) any {
 	switch v := x.(type) {
 	case string:
 		return varRe.ReplaceAllStringFunc(v, func(match string) string {
-			g := varRe.FindStringSubmatch(match)
-			name := g[1]
-			if name == "" {
-				name = g[2]
+			name := match[1:]
+			if len(name) >= 2 && name[0] == '{' {
+				name = name[1 : len(name)-1]
 			}
 			val, err := c.getVariable(name, cfg)
 			if err != nil {
@@ -709,16 +469,13 @@ func parseProvidersJSON(data []byte) ([]map[string]any, error) {
 				// providers is an array
 				return convertInterfaceArrayToMapArray(providers)
 			case map[string]interface{}:
-				// providers is a single object
-				converted := convertInterfaceMapToStringMap(providers)
-				return []map[string]any{converted}, nil
+				return []map[string]any{providers}, nil
 			default:
 				return nil, fmt.Errorf("'providers' field must be an array or object, got %T", providersRaw)
 			}
 		}
 		// Single provider object (no "providers" wrapper)
-		converted := convertInterfaceMapToStringMap(v)
-		return []map[string]any{converted}, nil
+		return []map[string]any{v}, nil
 
 	default:
 		return nil, fmt.Errorf("JSON root must be array or object, got %T", rawData)
@@ -733,19 +490,10 @@ func convertInterfaceArrayToMapArray(items []interface{}) ([]map[string]any, err
 		if !ok {
 			return nil, fmt.Errorf("item at index %d is not an object, got %T", i, item)
 		}
-		result[i] = convertInterfaceMapToStringMap(itemMap)
+		result[i] = itemMap
 	}
 
 	return result, nil
-}
-
-// convertInterfaceMapToStringMap converts map[string]interface{} to map[string]any
-func convertInterfaceMapToStringMap(input map[string]interface{}) map[string]any {
-	result := make(map[string]any, len(input))
-	for k, v := range input {
-		result[k] = v
-	}
-	return result
 }
 
 // processProvider handles individual provider processing
@@ -831,160 +579,173 @@ func (c *UtcpClient) CallToolStream(
 	toolName string,
 	args map[string]any,
 ) (transports.StreamResult, error) {
-	// fast path
-	if fn, ok := c.getFastStreamCaller(toolName); ok {
-		return fn(ctx, args)
-	}
-
-	prov, tr, callName, _, err := c.resolveTool(ctx, toolName)
+	resolved, err := c.resolveTool(ctx, toolName)
 	if err != nil {
 		return nil, err
 	}
-	fn := newFastStreamCaller(prov, tr, callName)
-	c.setFastStreamCallerSync(toolName, fn)
-	return fn(ctx, args)
+	return resolved.transport.CallToolStream(ctx, resolved.callName, args, resolved.provider)
 }
 
-// helper to resolve provider, transport, callName, and tool
-func (c *UtcpClient) resolveTool(ctx context.Context, toolName string) (Provider, ClientTransport, string, *Tool, error) {
-	// Lock-free cache lookup first
-	if res, ok := c.getResolved(toolName); ok {
-		return res.provider, res.transport, res.callName, res.tool, nil
+func (c *UtcpClient) resolveTool(ctx context.Context, toolName string) (*resolvedTool, error) {
+	if resolved, ok := c.cachedTool(toolName); ok {
+		return resolved, nil
 	}
 
-	// Fallback to legacy path (one-time work per tool)
 	providerName, suffix, ok := strings.Cut(toolName, ".")
 	if !ok {
-		return nil, nil, "", nil, fmt.Errorf("invalid tool name: %s", toolName)
+		return nil, fmt.Errorf("invalid tool name: %s", toolName)
 	}
 
 	prov, err := c.toolRepository.GetProvider(ctx, providerName)
 	if err != nil {
-		return nil, nil, "", nil, err
+		return nil, err
 	}
 	if prov == nil {
-		return nil, nil, "", nil, fmt.Errorf("provider not found: %s", providerName)
+		return nil, fmt.Errorf("provider not found: %s", providerName)
 	}
 
-	tools, err := c.toolRepository.GetToolsByProvider(ctx, providerName)
+	tool, err := c.toolRepository.GetTool(ctx, toolName)
 	if err != nil {
-		return nil, nil, "", nil, err
+		return nil, err
+	}
+	if tool == nil {
+		return nil, fmt.Errorf("tool not found: %s", toolName)
 	}
 
-	var selectedTool *Tool
-	for i := range tools {
-		if tools[i].Name == toolName {
-			selectedTool = &tools[i]
-			break
-		}
-	}
-	if selectedTool == nil {
-		return nil, nil, "", nil, fmt.Errorf("tool not found: %s", toolName)
-	}
-
-	// clone provider to avoid mutating repository entry
 	cloned := c.cloneProvider(*prov)
-
 	tr, ok := c.transports[string(cloned.Type())]
-	if !ok {
-		return nil, nil, "", nil, fmt.Errorf("no transport for provider type %s", cloned.Type())
+	if !ok || tr == nil {
+		return nil, fmt.Errorf("no transport for provider type %s", cloned.Type())
 	}
 
 	callName := toolName
 	if cloned.Type() == ProviderMCP || cloned.Type() == ProviderText {
-		// Strip provider prefix for transports that expect unprefixed names
 		callName = suffix
 	}
 
-	// Publish into both caches for future lock-free lookups
-	res := &resolvedTool{provider: cloned, transport: tr, callName: callName, tool: selectedTool}
-	c.toolResolutionCacheMu.Lock()
-	c.toolResolutionCache[toolName] = res
-	c.toolResolutionCacheMu.Unlock()
-
-	c.setResolvedSync(toolName, res)
-	c.setFastCallerSync(toolName, newFastCaller(cloned, tr, callName))
-	c.setFastStreamCallerSync(toolName, newFastStreamCaller(cloned, tr, callName))
-
-	return cloned, tr, callName, selectedTool, nil
+	resolved := &resolvedTool{provider: cloned, transport: tr, callName: callName}
+	c.publishResolved(toolName, resolved)
+	return resolved, nil
 }
 
-// getFastCaller retrieves a fastCaller for a tool from the cache (sync.Map)
-func (c *UtcpClient) getFastCaller(name string) (fastCaller, bool) {
-	if v, ok := c.callers.Load(name); ok {
-		return v.(fastCaller), true
+func newClientCache() *clientCache {
+	return &clientCache{
+		tools:         make(map[string]*resolvedTool),
+		providerTools: make(map[string][]Tool),
+	}
+}
+
+func (c *UtcpClient) cacheSnapshot() *clientCache {
+	if snapshot := c.cache.Load(); snapshot != nil {
+		return snapshot
+	}
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	if snapshot := c.cache.Load(); snapshot != nil {
+		return snapshot
+	}
+	snapshot := newClientCache()
+	c.cache.Store(snapshot)
+	return snapshot
+}
+
+func (c *UtcpClient) cachedTool(name string) (*resolvedTool, bool) {
+	if resolved, ok := c.cacheSnapshot().tools[name]; ok {
+		return resolved, true
+	}
+	if resolved, ok := c.fallback.Load(name); ok {
+		return resolved.(*resolvedTool), true
 	}
 	return nil, false
 }
 
-// setFastCallerSync safely stores the fast-caller in the cache.
-func (c *UtcpClient) setFastCallerSync(name string, fn fastCaller) {
-	c.callers.Store(name, fn)
+func (c *UtcpClient) cachedProviderTools(name string) ([]Tool, bool) {
+	providerTools, ok := c.cacheSnapshot().providerTools[name]
+	if !ok {
+		return nil, false
+	}
+	return append([]Tool(nil), providerTools...), true
 }
 
-func (c *UtcpClient) getFastStreamCaller(name string) (fastStreamCaller, bool) {
-	if v, ok := c.streams.Load(name); ok {
-		return v.(fastStreamCaller), true
-	}
-	return nil, false
-}
-func (c *UtcpClient) setFastStreamCallerSync(name string, fn fastStreamCaller) {
-	c.streams.Store(name, fn)
-}
+func (c *UtcpClient) publishProvider(name string, provider Provider, transport ClientTransport, tools []Tool) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
 
-func (c *UtcpClient) getResolved(name string) (*resolvedTool, bool) {
-	if v, ok := c.resolved.Load(name); ok {
-		return v.(*resolvedTool), true
-	}
-	return nil, false
-}
-func (c *UtcpClient) setResolvedSync(name string, res *resolvedTool) {
-	c.resolved.Store(name, res)
-}
-
-func (c *UtcpClient) deleteFastCaches(name string) {
-	c.resolved.Delete(name)
-	c.callers.Delete(name)
-	c.streams.Delete(name)
-}
-
-// newFastCaller creates a fastCaller function based on the provider, transport, and call name
-func newFastCaller(prov Provider, tr ClientTransport, call string) fastCaller {
-	p := prov
-	t := tr
-	cn := call
-	return func(ctx context.Context, args map[string]any) (any, error) {
-		return t.CallTool(ctx, cn, args, p, nil)
-	}
-}
-func newFastStreamCaller(prov Provider, tr ClientTransport, call string) fastStreamCaller {
-	p := prov
-	t := tr
-	cn := call
-	return func(ctx context.Context, args map[string]any) (transports.StreamResult, error) {
-		return t.CallToolStream(ctx, cn, args, p)
-	}
-}
-
-func (c *UtcpClient) ensureCaches() {
-	if c.providerToolsCache == nil {
-		c.providerToolsCache = make(map[string][]Tool)
-	}
-	if c.toolResolutionCache == nil {
-		c.toolResolutionCache = make(map[string]*resolvedTool)
-	}
-}
-
-// getOrCreateFastCaller tries to retrieve the fastCaller from cache, or creates and caches a new one.
-func (c *UtcpClient) getOrCreateFastCaller(toolName string, prov Provider, tr ClientTransport, callName string) (fastCaller, error) {
-	// Check cache first
-	if fn, ok := c.getFastCaller(toolName); ok {
-		return fn, nil
+	current := c.cache.Load()
+	if current == nil {
+		current = newClientCache()
 	}
 
-	// Resolve and cache the fast-caller
-	fn := newFastCaller(prov, tr, callName)
-	c.setFastCallerSync(toolName, fn)
+	resolved := make(map[string]*resolvedTool, len(current.tools)+len(tools))
+	for toolName, cached := range current.tools {
+		resolved[toolName] = cached
+	}
+	if previous := current.providerTools[name]; previous != nil {
+		for _, tool := range previous {
+			delete(resolved, tool.Name)
+		}
+	}
 
-	return fn, nil
+	toolsCopy := append([]Tool(nil), tools...)
+	for _, tool := range toolsCopy {
+		callName := tool.Name
+		if provider.Type() == ProviderMCP || provider.Type() == ProviderText {
+			if _, suffix, ok := strings.Cut(tool.Name, "."); ok {
+				callName = suffix
+			}
+		}
+		resolved[tool.Name] = &resolvedTool{
+			provider:  provider,
+			transport: transport,
+			callName:  callName,
+		}
+	}
+
+	providers := make(map[string][]Tool, len(current.providerTools)+1)
+	for providerName, cached := range current.providerTools {
+		providers[providerName] = cached
+	}
+	providers[name] = toolsCopy
+	c.cache.Store(&clientCache{tools: resolved, providerTools: providers})
+	c.clearFallbackProvider(name)
+}
+
+func (c *UtcpClient) publishResolved(name string, resolved *resolvedTool) {
+	c.fallback.Store(name, resolved)
+}
+
+func (c *UtcpClient) removeCachedProvider(name string) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	current := c.cache.Load()
+	if current == nil {
+		return
+	}
+
+	tools := make(map[string]*resolvedTool, len(current.tools))
+	for toolName, cached := range current.tools {
+		if strings.HasPrefix(toolName, name+".") || c.getProviderName(cached.provider) == name {
+			continue
+		}
+		tools[toolName] = cached
+	}
+	providers := make(map[string][]Tool, len(current.providerTools))
+	for providerName, cached := range current.providerTools {
+		if providerName != name {
+			providers[providerName] = cached
+		}
+	}
+	c.cache.Store(&clientCache{tools: tools, providerTools: providers})
+	c.clearFallbackProvider(name)
+}
+
+func (c *UtcpClient) clearFallbackProvider(name string) {
+	c.fallback.Range(func(key, value any) bool {
+		toolName := key.(string)
+		resolved := value.(*resolvedTool)
+		if strings.HasPrefix(toolName, name+".") || c.getProviderName(resolved.provider) == name {
+			c.fallback.Delete(toolName)
+		}
+		return true
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimizes tool lookup and streaming performance across the client and transports. Adds an indexed repository, snapshot-based client cache, safer streaming shutdown, and tighter HTTP auth/error handling.

- **Performance**
  - In‑memory repo: O(1) GetTool via index; fast RemoveTool/RemoveProvider; returns copies; benchmarks added.
  - Client: atomic snapshot cache for resolved tools and provider tools to reduce locks on hot paths.
  - Tag search and CodeMode ranking: top‑k selection with cancellation support and lighter tokenization for faster scoring.
  - Tool cache: atomic stats and cheaper SHA‑256 keys to cut contention and allocations.

- **Bug Fixes**
  - HTTP: thread‑safe OAuth token cache, non‑2xx now return detailed errors, switch to `gopkg.in/yaml.v3`, path params no longer mutate caller args, and POST sends JSON body.
  - Streaming (SSE/HTTP): Close now cancels producers and unblocks full buffers; SSE `CallToolStream` returns `StreamResult`; tests cover shutdown behavior.
  - TCP/UDP: use `net.JoinHostPort`, context‑aware dial, pooled UDP buffers, and simpler decoders for robustness.
  - Providers: new helpers (`ProviderName`, `SetProviderName`, `NewProvider`) for safer naming/creation and cleaner repo/client code; `SearchTools` now query‑based (pass a provider name to filter or use repository APIs directly).

<sup>Written for commit 5b918516b9a672a7fa9a572f8d3e80a0c169210d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/go-utcp/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

